### PR TITLE
feat: Remove references to enum members

### DIFF
--- a/src/EnumUtilities/CodeWriters/EnumExtensionsWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumExtensionsWriter.cs
@@ -155,7 +155,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 7 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 9 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 9 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -178,42 +192,14 @@ this.Write("            ");
         #line hidden
         
         #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
         #line hidden
         
         #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(" => nameof(");
-
-        
-        #line default
-        #line hidden
-        
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write(".");
+this.Write(" => \"");
 
         
         #line default
@@ -227,7 +213,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
         #line hidden
         
         #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DefaultBlock.ttinclude"
-this.Write("),\r\n");
+this.Write("\",\r\n");
 
         
         #line default
@@ -1524,7 +1510,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 8 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -1547,21 +1547,7 @@ this.Write("            ");
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
@@ -1577,7 +1563,7 @@ this.Write(" => ");
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.SerializationValue != null
                         ? Append($"\"{curr.SerializationValue}\"")
-                        : Append($"nameof({Model.RefName}.{curr.MemberName})")));
+                        : Append($"\"{curr.MemberName}\"")));
 
         
         #line default
@@ -1639,7 +1625,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 8 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -1662,21 +1662,7 @@ this.Write("            ");
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DescriptionBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
@@ -1752,7 +1738,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 8 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 10 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -1775,21 +1775,7 @@ this.Write("            ");
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
@@ -1841,7 +1827,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 26 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 28 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 28 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -1864,21 +1864,7 @@ this.Write("            ");
         #line hidden
         
         #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
@@ -1896,7 +1882,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(curr.Display?.ResourceName !=
                             ? Append(curr.Display.ResourceName)
                             : curr.Display?.Name != null
                                 ? Append($"\"{curr.Display.Name}\"")
-                                : Append($"nameof({Model.RefName}.{curr.MemberName})")));
+                                : Append($"\"{curr.MemberName}\"")));
 
         
         #line default
@@ -1956,7 +1942,21 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+this.Write(" value)\r\n    {\r\n        return (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
+this.Write(")value switch\r\n        {\r\n");
 
         
         #line default
@@ -1979,21 +1979,7 @@ this.Write("            ");
         #line hidden
         
         #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Extensions\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default

--- a/src/EnumUtilities/CodeWriters/EnumFactoryWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumFactoryWriter.cs
@@ -275,41 +275,27 @@ this.Write(";\r\n                break;\r\n");
         #line hidden
         
         #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("            case { } s when TryParseNumeric(s, comparisonType, out ");
+this.Write("            case { } s when TryParseNumeric(s, comparisonType, out numValue):\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
 
         
         #line default
         #line hidden
         
-        #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
-
-        
-        #line default
-        #line hidden
-        
-        #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" val):\r\n                numValue = val;\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
-
-        
-        #line default
-        #line hidden
-        
-        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 52 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 52 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
         }
 
@@ -317,70 +303,70 @@ this.Write(")numValue;\r\n        return true;\r\n");
         #line default
         #line hidden
         
-        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 57 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 66 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 66 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value\r\n    /// if the parse operation succeeds. If the parse operation fails, result contains the default value of the\r\n    /// underlying type of ");
 
         
         #line default
         #line hidden
         
-        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(". Note that this value need not be a member of the ");
 
         
         #line default
         #line hidden
         
-        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" enumeration.\r\n    /// </param>\r\n    /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>\r\n    public static bool TryParse(\r\n        [NotNullWhen(true)] string? name,\r\n        out ");
 
         
         #line default
         #line hidden
         
-        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 72 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 72 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 75 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
         if (Model.Values.Count == 0)
         {
@@ -389,14 +375,14 @@ this.Write(" result)\r\n    {\r\n");
         #line default
         #line hidden
         
-        #line 79 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 78 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("        return Enum.TryParse(name, out result);\r\n");
 
         
         #line default
         #line hidden
         
-        #line 80 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 79 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
         }
         else
@@ -406,28 +392,28 @@ this.Write("        return Enum.TryParse(name, out result);\r\n");
         #line default
         #line hidden
         
-        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("        ");
 
         
         #line default
         #line hidden
         
-        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
 
         
         #line default
         #line hidden
         
-        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" numValue;\r\n        switch (name)\r\n        {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 87 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
             foreach (var curr in Model.Values)
             {
@@ -436,42 +422,42 @@ this.Write(" numValue;\r\n        switch (name)\r\n        {\r\n");
         #line default
         #line hidden
         
-        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 91 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("            case \"");
 
         
         #line default
         #line hidden
         
-        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 91 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
 
         
         #line default
         #line hidden
         
-        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 91 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("\":\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
         #line hidden
         
-        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(";\r\n                break;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 95 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
             }
 
@@ -479,42 +465,28 @@ this.Write(";\r\n                break;\r\n");
         #line default
         #line hidden
         
-        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out ");
+        #line 97 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
 
         
         #line default
         #line hidden
         
-        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
-
-        
-        #line default
-        #line hidden
-        
-        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" val):\r\n                numValue = val;\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
-
-        
-        #line default
-        #line hidden
-        
-        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 103 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 103 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 107 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
         }
 
@@ -522,196 +494,196 @@ this.Write(")numValue;\r\n        return true;\r\n");
         #line default
         #line hidden
         
-        #line 110 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 108 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value\r\n    /// if the parse operation succeeds. If the parse operation fails, result contains the default value of the\r\n    /// underlying type of ");
 
         
         #line default
         #line hidden
         
-        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(". Note that this value need not be a member of the ");
 
         
         #line default
         #line hidden
         
-        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" enumeration.\r\n    /// </param>\r\n    /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>\r\n    public static bool TryParseIgnoreCase(\r\n        [NotNullWhen(true)] string? name,\r\n        out ");
 
         
         #line default
         #line hidden
         
-        #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 123 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 123 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryParse(name, StringComparison.OrdinalIgnoreCase, out result);\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 134 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 134 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("? TryParse(string? name)\r\n    {\r\n        return TryParse(name, out ");
 
         
         #line default
         #line hidden
         
-        #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 150 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 148 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 150 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 148 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 151 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 151 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("? TryParseIgnoreCase(string? name)\r\n    {\r\n        return TryParse(name, StringComparison.OrdinalIgnoreCase, out ");
 
         
         #line default
         #line hidden
         
-        #line 155 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 155 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"comparisonType\">One of the enumeration values that specifies how the strings will be compared.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 165 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 163 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 165 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 163 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    /// <exception cref=\"ArgumentException\"><paramref name=\"comparisonType\"/> is not a <see cref=\"StringComparison\"/> value.</exception>\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 167 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 167 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("? TryParse(string? name, StringComparison comparisonType)\r\n    {\r\n        return TryParse(name, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 171 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 171 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
-        #line 173 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 171 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
     }
 

--- a/src/EnumUtilities/CodeWriters/EnumFactoryWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumFactoryWriter.cs
@@ -169,481 +169,549 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 21 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (name)\r\n        {\r\n");
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 25 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
-    foreach (var curr in Model.Values)
-    {
-
-        
-        #line default
-        #line hidden
-        
-        #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("            case { } s when s.Equals(nameof(");
+        if (Model.Values.Count == 0)
+        {
 
         
         #line default
         #line hidden
         
-        #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+        #line 27 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("        return Enum.TryParse(name, out result);\r\n");
 
         
         #line default
         #line hidden
         
-        #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(".");
+        #line 28 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+        }
+        else
+        {
 
         
         #line default
         #line hidden
         
-        #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (name)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+            foreach (var curr in Model.Values)
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("            case { } s when s.Equals(\"");
+
+        
+        #line default
+        #line hidden
+        
+        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
 
         
         #line default
         #line hidden
         
-        #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("), comparisonType):\r\n                result = ");
+        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("\", comparisonType):\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+        #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
         #line hidden
         
-        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(".");
+        #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+            }
 
         
         #line default
         #line hidden
         
-        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 32 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-
-    }
-
-        
-        #line default
-        #line hidden
-        
-        #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write("            case { } s when TryParseNumeric(s, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
 
         
         #line default
         #line hidden
         
-        #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" val):\r\n                result = (");
+        #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" val):\r\n                numValue = val;\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(")val;\r\n                return true;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
+        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 49 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+        }
+
+        
+        #line default
+        #line hidden
+        
+        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 66 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 49 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 66 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value\r\n    /// if the parse operation succeeds. If the parse operation fails, result contains the default value of the\r\n    /// underlying type of ");
 
         
         #line default
         #line hidden
         
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(". Note that this value need not be a member of the ");
 
         
         #line default
         #line hidden
         
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" enumeration.\r\n    /// </param>\r\n    /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>\r\n    public static bool TryParse(\r\n        [NotNullWhen(true)] string? name,\r\n        out ");
 
         
         #line default
         #line hidden
         
-        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (name)\r\n        {\r\n");
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 60 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 75 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
-    foreach (var curr in Model.Values)
-    {
-
-        
-        #line default
-        #line hidden
-        
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("            case nameof(");
+        if (Model.Values.Count == 0)
+        {
 
         
         #line default
         #line hidden
         
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+        #line 79 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("        return Enum.TryParse(name, out result);\r\n");
 
         
         #line default
         #line hidden
         
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(".");
+        #line 80 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+        }
+        else
+        {
 
         
         #line default
         #line hidden
         
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("        ");
 
         
         #line default
         #line hidden
         
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("):\r\n                result = ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(".");
-
-        
-        #line default
-        #line hidden
-        
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-
-    }
-
-        
-        #line default
-        #line hidden
-        
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
 
         
         #line default
         #line hidden
         
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" val):\r\n                result = (");
+        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (name)\r\n        {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 71 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+            foreach (var curr in Model.Values)
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("            case \"");
+
+        
+        #line default
+        #line hidden
+        
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("\":\r\n                numValue = ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 95 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+            }
+
+        
+        #line default
+        #line hidden
+        
+        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" val):\r\n                numValue = val;\r\n                break;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 71 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(")val;\r\n                return true;\r\n            default:\r\n                return Enum.TryParse(name, out result);\r\n        }\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
+        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 107 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+
+        }
+
+        
+        #line default
+        #line hidden
+        
+        #line 110 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value\r\n    /// if the parse operation succeeds. If the parse operation fails, result contains the default value of the\r\n    /// underlying type of ");
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(". Note that this value need not be a member of the ");
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 120 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" enumeration.\r\n    /// </param>\r\n    /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>\r\n    public static bool TryParseIgnoreCase(\r\n        [NotNullWhen(true)] string? name,\r\n        out ");
 
         
         #line default
         #line hidden
         
-        #line 91 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 91 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryParse(name, StringComparison.OrdinalIgnoreCase, out result);\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 102 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 102 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    public static ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("? TryParse(string? name)\r\n    {\r\n        return TryParse(name, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 107 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 107 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
-
-        
-        #line default
-        #line hidden
-        
-        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    public static ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 119 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 119 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("? TryParseIgnoreCase(string? name)\r\n    {\r\n        return TryParse(name, StringComparison.OrdinalIgnoreCase, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 121 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 121 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"comparisonType\">One of the enumeration values that specifies how the strings will be compared.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 131 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
-
-        
-        #line default
-        #line hidden
-        
-        #line 131 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    /// <exception cref=\"ArgumentException\"><paramref name=\"comparisonType\"/> is not a <see cref=\"StringComparison\"/> value.</exception>\r\n    public static ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 135 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 135 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("? TryParse(string? name, StringComparison comparisonType)\r\n    {\r\n        return TryParse(name, comparisonType, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
         #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 139 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("? TryParse(string? name)\r\n    {\r\n        return TryParse(name, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 150 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+
+        
+        #line default
+        #line hidden
+        
+        #line 150 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    public static ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("? TryParseIgnoreCase(string? name)\r\n    {\r\n        return TryParse(name, StringComparison.OrdinalIgnoreCase, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 155 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 155 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the name or numeric value of one or more enumerated constants to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"name\">The case-sensitive string representation of the enumeration name or underlying value to convert.</param>\r\n    /// <param name=\"comparisonType\">One of the enumeration values that specifies how the strings will be compared.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 165 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+
+        
+        #line default
+        #line hidden
+        
+        #line 165 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains <c>null</c> value.\r\n    /// </returns>\r\n    /// <exception cref=\"ArgumentException\"><paramref name=\"comparisonType\"/> is not a <see cref=\"StringComparison\"/> value.</exception>\r\n    public static ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 169 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write("? TryParse(string? name, StringComparison comparisonType)\r\n    {\r\n        return TryParse(name, comparisonType, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 171 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 171 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 173 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DefaultBlock.ttinclude"
 
     }
 
@@ -719,73 +787,135 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 24 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (enumMemberValue)\r\n        {\r\n");
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 28 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 26 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 
-        foreach (var curr in Model.Values)
+        if (Model.Values.Count == 0)
         {
 
         
         #line default
         #line hidden
         
+        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("        result = default;\r\n        return false;\r\n");
+
+        
+        #line default
+        #line hidden
+        
         #line 32 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+
+        }
+        else
+        {
+
+        
+        #line default
+        #line hidden
+        
+        #line 37 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 37 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 37 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (enumMemberValue)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+
+            foreach (var curr in Model.Values)
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 44 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write("            case { } s when s.Equals(");
 
         
         #line default
         #line hidden
         
-        #line 32 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 44 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.SerializationValue != null
-                        ? Append($"\"{curr.SerializationValue}\"")
-                        : Append($"nameof({Model.RefName}.{curr.MemberName})")));
+                            ? Append($"\"{curr.SerializationValue}\"")
+                            : Append($"\"{curr.MemberName}\"")));
 
         
         #line default
         #line hidden
         
-        #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(", comparisonType):\r\n                result = ");
+        #line 47 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(", comparisonType):\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 48 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 48 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 50 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+
+            }
+
+        
+        #line default
+        #line hidden
+        
+        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(".");
+        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 38 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 60 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 
         }
 
@@ -793,154 +923,154 @@ this.Write(";\r\n                return true;\r\n");
         #line default
         #line hidden
         
-        #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the value associated with one enumerated constant to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"enumMemberValue\">The value as defined with <see cref=\"System.Runtime.Serialization.EnumMemberAttribute\"/>.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
+        #line 63 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the value associated with one enumerated constant to\r\n    /// an equivalent enumerated object. The return value indicates whether the conversion succeeded.\r\n    /// </summary>\r\n    /// <param name=\"enumMemberValue\">The value as defined with <see cref=\"System.Runtime.Serialization.EnumMemberAttribute\"/>.</param>\r\n    /// <param name=\"result\">\r\n    /// When this method returns, result contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 71 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 71 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(" whose value is represented by value\r\n    /// if the parse operation succeeds. If the parse operation fails, result contains the default value of the\r\n    /// underlying type of ");
 
         
         #line default
         #line hidden
         
-        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(". Note that this value need not be a member of the ");
 
         
         #line default
         #line hidden
         
-        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 73 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(" enumeration.\r\n    /// </param>\r\n    /// <returns><c>true</c> if the value parameter was converted successfully; otherwise, <c>false</c>.</returns>\r\n    public static bool TryParseFromEnumMemberValue([NotNullWhen(true)] string? enumMemberValue, out ");
 
         
         #line default
         #line hidden
         
-        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryParseFromEnumMemberValue(enumMemberValue, StringComparison.Ordinal, out result);\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the value associated with one enumerated constant to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"enumMemberValue\">The value as defined with <see cref=\"System.Runtime.Serialization.EnumMemberAttribute\"/>.</param>\r\n    /// <param name=\"comparisonType\">One of the enumeration values that specifies how the strings will be compared.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
 
         
         #line default
         #line hidden
         
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
 
         
         #line default
         #line hidden
         
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains a null value.\r\n    /// </returns>\r\n    /// <exception cref=\"ArgumentException\"><paramref name=\"comparisonType\"/> is not a <see cref=\"StringComparison\"/> value.</exception>\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+        #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write("? TryParseFromEnumMemberValue(string? enumMemberValue, StringComparison comparisonType)\r\n    {\r\n        return TryParseFromEnumMemberValue(enumMemberValue, comparisonType, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the value associated with one enumerated constant to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"enumMemberValue\">The value as defined with <see cref=\"System.Runtime.Serialization.EnumMemberAttribute\"/>.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
-
-        
-        #line default
-        #line hidden
-        
-        #line 85 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains a null value.\r\n    /// </returns>\r\n    public static ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write("? TryParseFromEnumMemberValue(string? enumMemberValue)\r\n    {\r\n        return TryParseFromEnumMemberValue(enumMemberValue, StringComparison.Ordinal, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 90 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 90 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
         #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("? TryParseFromEnumMemberValue(string? enumMemberValue, StringComparison comparisonType)\r\n    {\r\n        return TryParseFromEnumMemberValue(enumMemberValue, comparisonType, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n\r\n    /// <summary>\r\n    /// Converts the string representation of the value associated with one enumerated constant to\r\n    /// an equivalent enumerated object.\r\n    /// </summary>\r\n    /// <param name=\"enumMemberValue\">The value as defined with <see cref=\"System.Runtime.Serialization.EnumMemberAttribute\"/>.</param>\r\n    /// <returns>\r\n    /// Contains an object of type ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 103 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+
+        
+        #line default
+        #line hidden
+        
+        #line 103 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(" whose value is represented by value if the parse operation succeeds.\r\n    /// If the parse operation fails, result contains a null value.\r\n    /// </returns>\r\n    public static ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 106 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 106 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write("? TryParseFromEnumMemberValue(string? enumMemberValue)\r\n    {\r\n        return TryParseFromEnumMemberValue(enumMemberValue, StringComparison.Ordinal, out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 108 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 108 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 110 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\EnumMemberBlock.ttinclude"
 
     }
 
@@ -974,71 +1104,133 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 11 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (description)\r\n        {\r\n");
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 13 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 
-        foreach (var curr in Model.Values.Where(x => x.Description != null))
+        if (Model.Values.All(x => x.Description == null))
         {
 
         
         #line default
         #line hidden
         
+        #line 17 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write("        result = default;\r\n        return false;\r\n");
+
+        
+        #line default
+        #line hidden
+        
         #line 19 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+
+        }
+        else
+        {
+
+        
+        #line default
+        #line hidden
+        
+        #line 24 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 24 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 24 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (description)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 27 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+
+            foreach (var curr in Model.Values.Where(x => x.Description != null))
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write("            case { } s when s.Equals(\"");
 
         
         #line default
         #line hidden
         
-        #line 19 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.Description));
 
         
         #line default
         #line hidden
         
-        #line 19 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write("\", comparisonType):\r\n                result = ");
+        #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write("\", comparisonType):\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 20 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 32 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 32 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+
+            }
+
+        
+        #line default
+        #line hidden
+        
+        #line 37 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 42 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 20 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write(".");
+        #line 42 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 20 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 20 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 22 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 44 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 
         }
 
@@ -1046,84 +1238,84 @@ this.Write(";\r\n                return true;\r\n");
         #line default
         #line hidden
         
-        #line 25 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
-this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n    }\r\n\r\n    public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out ");
+        #line 47 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+this.Write("    }\r\n\r\n    public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out ");
 
         
         #line default
         #line hidden
         
-        #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 49 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 49 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryCreateFromDescription(description, StringComparison.Ordinal, out result);\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write("? TryCreateFromDescription(string? description, StringComparison comparisonType)\r\n    {\r\n        return TryCreateFromDescription(description, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 38 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 38 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 59 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 59 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write("? TryCreateFromDescription(string? description)\r\n    {\r\n        return TryCreateFromDescription(description, StringComparison.Ordinal, out ");
 
         
         #line default
         #line hidden
         
-        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 61 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 61 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
-        #line 45 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
+        #line 63 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DescriptionBlock.ttinclude"
 
     }
 
@@ -1157,73 +1349,135 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 11 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (displayShortName)\r\n        {\r\n");
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 15 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 13 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
-            foreach (var curr in Model.Values.Where(x => x.Display?.ShortName != null))
+            if (Model.Values.All(x => x.Display?.ShortName == null))
             {
 
         
         #line default
         #line hidden
         
-        #line 19 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 17 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        return TryCreateFromDisplayName(displayShortName, comparisonType, out result);\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 18 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+            }
+            else
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (displayShortName)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 26 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                foreach (var curr in Model.Values.Where(x => x.Display?.ShortName != null))
+                {
+
+        
+        #line default
+        #line hidden
+        
+        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("            case { } s when s.Equals(");
 
         
         #line default
         #line hidden
         
-        #line 19 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 30 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.Display!.ResourceShortName != null
-                            ? Append(curr.Display.ResourceShortName)
-                            : Append($"\"{curr.Display.ShortName}\"")));
+                                ? Append(curr.Display.ResourceShortName)
+                                : Append($"\"{curr.Display.ShortName}\"")));
 
         
         #line default
         #line hidden
         
-        #line 22 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(", comparisonType):\r\n                result = ");
+        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(", comparisonType):\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 34 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 36 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                }
+
+        
+        #line default
+        #line hidden
+        
+        #line 39 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("            default:\r\n                return TryCreateFromDisplayName(displayShortName, comparisonType, out result);\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(".");
+        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 23 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 25 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 45 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
             }
 
@@ -1231,160 +1485,222 @@ this.Write(";\r\n                return true;\r\n");
         #line default
         #line hidden
         
-        #line 28 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("            default:\r\n                return TryCreateFromDisplayName(displayShortName, comparisonType, out result);\r\n        }\r\n    }\r\n\r\n    public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out ");
+        #line 48 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("    }\r\n\r\n    public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out ");
 
         
         #line default
         #line hidden
         
-        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 50 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 50 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryCreateFromDisplayShortName(displayShortName, StringComparison.Ordinal, out result);\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 38 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 38 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("? TryCreateFromDisplayShortName(string? displayShortName, StringComparison comparisonType)\r\n    {\r\n        return TryCreateFromDisplayShortName(displayShortName, comparisonType, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 43 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("? TryCreateFromDisplayShortName(string? displayShortName)\r\n    {\r\n        return TryCreateFromDisplayShortName(displayShortName, StringComparison.Ordinal, out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 45 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 45 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static bool TryCreateFromDisplayName(\r\n        [NotNullWhen(true)] string? displayName,\r\n        StringComparison comparisonType,\r\n        out ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (displayName)\r\n        {\r\n");
 
         
         #line default
         #line hidden
         
         #line 55 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-
-            foreach (var curr in Model.Values)
-            {
+this.Write("? TryCreateFromDisplayShortName(string? displayShortName, StringComparison comparisonType)\r\n    {\r\n        return TryCreateFromDisplayShortName(displayShortName, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 59 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("            case { } s when s.Equals(");
-
-        
-        #line default
-        #line hidden
-        
-        #line 59 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.Display?.ResourceName != null
-                            ? Append(curr.Display.ResourceName)
-                            : curr.Display?.Name != null
-                                ? Append($"\"{curr.Display.Name}\"")
-                                : Append($"nameof({Model.RefName}.{curr.MemberName})")));
-
-        
-        #line default
-        #line hidden
-        
-        #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(", comparisonType):\r\n                result = ");
-
-        
-        #line default
-        #line hidden
-        
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 57 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(".");
+        #line 57 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+        #line 60 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
+        #line 60 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("? TryCreateFromDisplayShortName(string? displayShortName)\r\n    {\r\n        return TryCreateFromDisplayShortName(displayShortName, StringComparison.Ordinal, out ");
 
         
         #line default
         #line hidden
         
-        #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static bool TryCreateFromDisplayName(\r\n        [NotNullWhen(true)] string? displayName,\r\n        StringComparison comparisonType,\r\n        out ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 68 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" result)\r\n    {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+            if (Model.Values.Count == 0)
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        result = default;\r\n        return false;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+            }
+            else
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 81 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 81 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 81 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (displayName)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 84 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                foreach (var curr in Model.Values)
+                {
+
+        
+        #line default
+        #line hidden
+        
+        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("            case { } s when s.Equals(");
+
+        
+        #line default
+        #line hidden
+        
+        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.Display?.ResourceName != null
+                                ? Append(curr.Display.ResourceName)
+                                : curr.Display?.Name != null
+                                    ? Append($"\"{curr.Display.Name}\"")
+                                    : Append($"\"{curr.MemberName}\"")));
+
+        
+        #line default
+        #line hidden
+        
+        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(", comparisonType):\r\n                numValue = ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 96 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                }
+
+        
+        #line default
+        #line hidden
+        
+        #line 99 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 104 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+
+        
+        #line default
+        #line hidden
+        
+        #line 104 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 106 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
             }
 
@@ -1392,84 +1708,84 @@ this.Write(";\r\n                return true;\r\n");
         #line default
         #line hidden
         
-        #line 70 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n    }\r\n\r\n    public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out ");
+        #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("    }\r\n\r\n    public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out ");
 
         
         #line default
         #line hidden
         
-        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 111 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 111 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryCreateFromDisplayName(displayName, StringComparison.Ordinal, out result);\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 81 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 81 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("? TryCreateFromDisplayName(string? displayName, StringComparison comparisonType)\r\n    {\r\n        return TryCreateFromDisplayName(displayName, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 83 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 83 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 121 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 86 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 121 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("? TryCreateFromDisplayName(string? displayName)\r\n    {\r\n        return TryCreateFromDisplayName(displayName, StringComparison.Ordinal, out ");
 
         
         #line default
         #line hidden
         
-        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 123 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 123 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
-        #line 90 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
         }
 
@@ -1477,7 +1793,7 @@ this.Write(" result) ? result : null;\r\n    }\r\n");
         #line default
         #line hidden
         
-        #line 93 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 128 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
         if (Model.HasDisplayDescription)
         {
@@ -1486,88 +1802,150 @@ this.Write(" result) ? result : null;\r\n    }\r\n");
         #line default
         #line hidden
         
-        #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 133 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("\r\n    public static bool TryCreateFromDescription(\r\n        [NotNullWhen(true)] string? description,\r\n        StringComparison comparisonType,\r\n        out ");
 
         
         #line default
         #line hidden
         
-        #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(" result)\r\n    {\r\n        switch (description)\r\n        {\r\n");
+        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" result)\r\n    {\r\n");
 
         
         #line default
         #line hidden
         
-        #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 138 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
-            foreach (var curr in Model.Values.Where(x => x.Display?.Description != null))
+            if (Model.Values.All(x => x.Display?.Description == null))
             {
 
         
         #line default
         #line hidden
         
-        #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 142 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        result = default;\r\n        return false;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 144 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+            }
+            else
+            {
+
+        
+        #line default
+        #line hidden
+        
+        #line 149 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("        ");
+
+        
+        #line default
+        #line hidden
+        
+        #line 149 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+
+        
+        #line default
+        #line hidden
+        
+        #line 149 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(" numValue;\r\n        switch (description)\r\n        {\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 152 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                foreach (var curr in Model.Values.Where(x => x.Display?.Description != null))
+                {
+
+        
+        #line default
+        #line hidden
+        
+        #line 156 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("            case { } s when s.Equals(");
 
         
         #line default
         #line hidden
         
-        #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 156 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(curr.Display!.ResourceDescription != null
-                            ? Append(curr.Display.ResourceDescription)
-                            : Append($"\"{curr.Display.Description}\"")));
+                                ? Append(curr.Display.ResourceDescription)
+                                : Append($"\"{curr.Display.Description}\"")));
 
         
         #line default
         #line hidden
         
-        #line 112 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(", comparisonType):\r\n                result = ");
+        #line 159 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(", comparisonType):\r\n                numValue = ");
 
         
         #line default
         #line hidden
         
-        #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 160 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+
+        
+        #line default
+        #line hidden
+        
+        #line 160 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(";\r\n                break;\r\n");
+
+        
+        #line default
+        #line hidden
+        
+        #line 162 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+
+                }
+
+        
+        #line default
+        #line hidden
+        
+        #line 165 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n\r\n        result = (");
+
+        
+        #line default
+        #line hidden
+        
+        #line 170 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(".");
+        #line 170 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write(")numValue;\r\n        return true;\r\n");
 
         
         #line default
         #line hidden
         
-        #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write(";\r\n                return true;\r\n");
-
-        
-        #line default
-        #line hidden
-        
-        #line 115 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 172 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
             }
 
@@ -1575,84 +1953,84 @@ this.Write(";\r\n                return true;\r\n");
         #line default
         #line hidden
         
-        #line 118 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
-this.Write("            default:\r\n                result = default;\r\n                return false;\r\n        }\r\n    }\r\n\r\n    public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out ");
+        #line 175 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+this.Write("    }\r\n\r\n    public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out ");
 
         
         #line default
         #line hidden
         
-        #line 124 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 177 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 124 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 177 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result)\r\n    {\r\n        return TryCreateFromDescription(description, StringComparison.Ordinal, out result);\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 129 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 182 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 129 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 182 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("? TryCreateFromDescription(string? description, StringComparison comparisonType)\r\n    {\r\n        return TryCreateFromDescription(description, comparisonType, out ");
 
         
         #line default
         #line hidden
         
-        #line 131 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 184 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 131 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 184 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n\r\n    public static ");
 
         
         #line default
         #line hidden
         
-        #line 134 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 187 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 134 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 187 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write("? TryCreateFromDescription(string? description)\r\n    {\r\n        return TryCreateFromDescription(description, StringComparison.Ordinal, out ");
 
         
         #line default
         #line hidden
         
-        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 189 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
 
         
         #line default
         #line hidden
         
-        #line 136 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 189 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 this.Write(" result) ? result : null;\r\n    }\r\n");
 
         
         #line default
         #line hidden
         
-        #line 138 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
+        #line 191 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\DisplayBlock.ttinclude"
 
         }
     }
@@ -1729,7 +2107,7 @@ this.Write("[] GetValues()\r\n    {\r\n        return new[]\r\n        {\r\n");
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write("            ");
+this.Write("            (");
 
         
         #line default
@@ -1743,14 +2121,14 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write(".");
+this.Write(")");
 
         
         #line default
         #line hidden
         
         #line 16 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
 
         
         #line default
@@ -1816,21 +2194,7 @@ this.Write(".</returns>\r\n    public static string[] GetNames()\r\n    {\r\n   
         #line hidden
         
         #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write("            nameof(");
-
-        
-        #line default
-        #line hidden
-        
-        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-
-        
-        #line default
-        #line hidden
-        
-        #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write(".");
+this.Write("            \"");
 
         
         #line default
@@ -1844,7 +2208,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
         #line hidden
         
         #line 33 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\Factory\MiscellaneousBlock.ttinclude"
-this.Write("),\r\n");
+this.Write("\",\r\n");
 
         
         #line default

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
@@ -145,7 +145,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             this.Write("\r\n        ");
             
             #line 51 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue(addReturn: true)));
+            this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue(addReturn: true, castToEnum: true)));
             
             #line default
             #line hidden
@@ -347,13 +347,20 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
     protected override bool CanGenerateFor(EnumToGenerate model) =>
         (model.SelectedGenerators & SelectedGenerators.JsonConverter) != 0;
 
-    private None AppendFallbackValue(bool addReturn = false)
+    private None AppendFallbackValue(bool addReturn = false, bool castToEnum = false)
     {
         object? fallbackValue = Model.JsonConverterGeneratorOptions!.DeserializationFailureFallbackValue;
-        return fallbackValue is not null
-            ? Append(
-                $"{(addReturn ? "return " : "")}{(NeedNumberCasting() ? $"({Model.UnderlyingType})" : "")}{fallbackValue}")
-            : Append("throw new JsonException()");
+        if (fallbackValue is null)
+            return Append("throw new JsonException()");
+
+        if (addReturn)
+            Append("return ");
+        if (castToEnum)
+            Append($"({Model.RefName})");
+        if (NeedNumberCasting())
+            Append($"({Model.UnderlyingType})");
+
+        return Append($"{fallbackValue}");
     }
 
     private static int GetEncodedLength(string value) => value.Sum(c => c < 128 ? 1 : 6);

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
@@ -109,7 +109,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(" Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)\r\n    {\r\n        if (reader.TokenType == JsonTokenType.String)\r\n            return ReadFromString(ref reader);\r\n");
+            this.Write(" Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)\r\n    {\r\n        if (reader.TokenType == JsonTokenType.String)\r\n            return (");
+            
+            #line 40 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+            
+            #line default
+            #line hidden
+            this.Write(")ReadFromString(ref reader);\r\n");
             
             #line 41 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
 
@@ -119,7 +126,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write("        if (reader.TokenType == JsonTokenType.Number)\r\n            return ReadFromNumber(ref reader);\r\n");
+            this.Write("        if (reader.TokenType == JsonTokenType.Number)\r\n            return (");
+            
+            #line 46 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+            
+            #line default
+            #line hidden
+            this.Write(")ReadFromNumber(ref reader);\r\n");
             
             #line 47 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
 
@@ -142,7 +156,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(" value, JsonSerializerOptions options)\r\n    {\r\n        switch (value)\r\n        {\r\n");
+            this.Write(" value, JsonSerializerOptions options)\r\n    {\r\n        switch ((");
+            
+            #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(")value)\r\n        {\r\n");
             
             #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
 
@@ -155,14 +176,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             this.Write("            case ");
             
             #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-            
-            #line default
-            #line hidden
-            this.Write(".");
-            
-            #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
             
             #line default
             #line hidden
@@ -185,7 +199,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             this.Write("            default:\r\n                writer.WriteStringValue(value.ToString());\r\n                break;\r\n        }\r\n    }\r\n\r\n    private ");
             
             #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
@@ -211,21 +225,20 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.JsonPropertyName is not null || curr.SerializationValue is not null
                     ? Append($"\"{curr.JsonPropertyName ?? curr.SerializationValue}\"")
-                    : Append($"nameof({Model.RefName}.{curr.MemberName})")));
+                    : Append($"\"{curr.MemberName}\"")));
             
             #line default
             #line hidden
             this.Write(" => ");
             
             #line 97 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(NeedNumberCasting() ? Append($"({Model.UnderlyingType})") : Append("")));
             
             #line default
             #line hidden
-            this.Write(".");
             
             #line 97 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
             
             #line default
             #line hidden
@@ -245,7 +258,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(" result) ? result : ");
+            this.Write(" result) ? (");
+            
+            #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(")result : ");
             
             #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue()));
@@ -265,7 +285,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             this.Write("\r\n    private ");
             
             #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
@@ -283,14 +303,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(" value)\r\n            ? (");
-            
-            #line 112 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-            
-            #line default
-            #line hidden
-            this.Write(")value\r\n            : ");
+            this.Write(" value)\r\n            ? value\r\n            : ");
             
             #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue()));
@@ -338,11 +351,13 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
     {
         object? fallbackValue = Model.JsonConverterGeneratorOptions!.DeserializationFailureFallbackValue;
         return fallbackValue is not null
-            ? Append($"{(addReturn ? "return " : "")}({Model.RefName}){fallbackValue}")
+            ? Append(
+                $"{(addReturn ? "return " : "")}{(NeedNumberCasting() ? $"({Model.UnderlyingType})" : "")}{fallbackValue}")
             : Append("throw new JsonException()");
     }
 
     private static int GetEncodedLength(string value) => value.Sum(c => c < 128 ? 1 : 6);
+    private bool NeedNumberCasting() => Model.UnderlyingType is "byte" or "short" or "sbyte" or "ushort";
 
         
         #line default

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.cs
@@ -357,7 +357,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             Append("return ");
         if (castToEnum)
             Append($"({Model.RefName})");
-        if (NeedNumberCasting())
+        if (!castToEnum && NeedNumberCasting())
             Append($"({Model.UnderlyingType})");
 
         return Append($"{fallbackValue}");

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
@@ -144,7 +144,7 @@ using System.Text.Json.Serialization;
             Append("return ");
         if (castToEnum)
             Append($"({Model.RefName})");
-        if (NeedNumberCasting())
+        if (!castToEnum && NeedNumberCasting())
             Append($"({Model.UnderlyingType})");
 
         return Append($"{fallbackValue}");

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
@@ -48,7 +48,7 @@ using System.Text.Json.Serialization;
     }
 #>
 
-        <#= AppendFallbackValue(addReturn: true) #>;
+        <#= AppendFallbackValue(addReturn: true, castToEnum: true) #>;
     }
 
     public override void Write(Utf8JsonWriter writer, <#= Model.Name #> value, JsonSerializerOptions options)
@@ -134,13 +134,20 @@ using System.Text.Json.Serialization;
     protected override bool CanGenerateFor(EnumToGenerate model) =>
         (model.SelectedGenerators & SelectedGenerators.JsonConverter) != 0;
 
-    private None AppendFallbackValue(bool addReturn = false)
+    private None AppendFallbackValue(bool addReturn = false, bool castToEnum = false)
     {
         object? fallbackValue = Model.JsonConverterGeneratorOptions!.DeserializationFailureFallbackValue;
-        return fallbackValue is not null
-            ? Append(
-                $"{(addReturn ? "return " : "")}{(NeedNumberCasting() ? $"({Model.UnderlyingType})" : "")}{fallbackValue}")
-            : Append("throw new JsonException()");
+        if (fallbackValue is null)
+            return Append("throw new JsonException()");
+
+        if (addReturn)
+            Append("return ");
+        if (castToEnum)
+            Append($"({Model.RefName})");
+        if (NeedNumberCasting())
+            Append($"({Model.UnderlyingType})");
+
+        return Append($"{fallbackValue}");
     }
 
     private static int GetEncodedLength(string value) => value.Sum(c => c < 128 ? 1 : 6);

--- a/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
+++ b/src/EnumUtilities/CodeWriters/EnumJsonConverterWriter.tt
@@ -37,13 +37,13 @@ using System.Text.Json.Serialization;
     public override <#= Model.Name #> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.String)
-            return ReadFromString(ref reader);
+            return (<#= Model.RefName #>)ReadFromString(ref reader);
 <#
     if (Model.JsonConverterGeneratorOptions.AllowIntegerValues)
     {
 #>
         if (reader.TokenType == JsonTokenType.Number)
-            return ReadFromNumber(ref reader);
+            return (<#= Model.RefName #>)ReadFromNumber(ref reader);
 <#
     }
 #>
@@ -53,13 +53,13 @@ using System.Text.Json.Serialization;
 
     public override void Write(Utf8JsonWriter writer, <#= Model.Name #> value, JsonSerializerOptions options)
     {
-        switch (value)
+        switch ((<#= Model.UnderlyingType #>)value)
         {
 <#
     foreach (var curr in Model.UniqueValues)
     {
 #>
-            case <#= Model.RefName #>.<#= curr.MemberName #>:
+            case <#= curr.MemberValue #>:
                 writer.WriteStringValue("<#= curr.JsonPropertyName ?? curr.SerializationValue ?? curr.MemberName #>"u8);
                 break;
 <#
@@ -71,7 +71,7 @@ using System.Text.Json.Serialization;
         }
     }
 
-    private <#= Model.Name #> ReadFromString(ref Utf8JsonReader reader)
+    private <#= Model.UnderlyingType #> ReadFromString(ref Utf8JsonReader reader)
     {
 #if NET7_0_OR_GREATER
         int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
@@ -94,11 +94,11 @@ using System.Text.Json.Serialization;
             <#=
                 curr.JsonPropertyName is not null || curr.SerializationValue is not null
                     ? Append($"\"{curr.JsonPropertyName ?? curr.SerializationValue}\"")
-                    : Append($"nameof({Model.RefName}.{curr.MemberName})") #> => <#= Model.RefName #>.<#= curr.MemberName #>,
+                    : Append($"\"{curr.MemberName}\"") #> => <#= NeedNumberCasting() ? Append($"({Model.UnderlyingType})") : Append("") #><#= curr.MemberValue #>,
 <#
     }
 #>
-            _ => Enum.TryParse(name, out <#= Model.RefName #> result) ? result : <#= AppendFallbackValue() #>
+            _ => Enum.TryParse(name, out <#= Model.RefName #> result) ? (<#= Model.UnderlyingType #>)result : <#= AppendFallbackValue() #>
         };
     }
 <#
@@ -106,10 +106,10 @@ using System.Text.Json.Serialization;
     {
 #>
 
-    private <#= Model.Name #> ReadFromNumber(ref Utf8JsonReader reader)
+    private <#= Model.UnderlyingType #> ReadFromNumber(ref Utf8JsonReader reader)
     {
         return reader.TryGet<#= CSharpExtensions.GetTypeNameFromCSharpKeyword(Model.UnderlyingType) #>(out <#= Model.UnderlyingType #> value)
-            ? (<#= Model.RefName #>)value
+            ? value
             : <#= AppendFallbackValue() #>;
     }
 <#
@@ -138,9 +138,11 @@ using System.Text.Json.Serialization;
     {
         object? fallbackValue = Model.JsonConverterGeneratorOptions!.DeserializationFailureFallbackValue;
         return fallbackValue is not null
-            ? Append($"{(addReturn ? "return " : "")}({Model.RefName}){fallbackValue}")
+            ? Append(
+                $"{(addReturn ? "return " : "")}{(NeedNumberCasting() ? $"({Model.UnderlyingType})" : "")}{fallbackValue}")
             : Append("throw new JsonException()");
     }
 
     private static int GetEncodedLength(string value) => value.Sum(c => c < 128 ? 1 : 6);
+    private bool NeedNumberCasting() => Model.UnderlyingType is "byte" or "short" or "sbyte" or "ushort";
 #>

--- a/src/EnumUtilities/CodeWriters/EnumValidationWriter.cs
+++ b/src/EnumUtilities/CodeWriters/EnumValidationWriter.cs
@@ -91,7 +91,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(" value)\r\n    {\r\n        return value switch\r\n        {\r\n");
+            this.Write(" value)\r\n    {\r\n        return (");
+            
+            #line 29 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(")value switch\r\n        {\r\n");
             
             #line 31 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
 
@@ -104,14 +111,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             this.Write("            ");
             
             #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-            
-            #line default
-            #line hidden
-            this.Write(".");
-            
-            #line 35 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
             
             #line default
             #line hidden
@@ -134,21 +134,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write("            { } s when s.Equals(nameof(");
-            
-            #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-            
-            #line default
-            #line hidden
-            this.Write(".");
+            this.Write("            { } s when s.Equals(\"");
             
             #line 53 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
             
             #line default
             #line hidden
-            this.Write("), comparisonType) => true,\r\n");
+            this.Write("\", comparisonType) => true,\r\n");
             
             #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
 
@@ -167,21 +160,14 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write("            nameof(");
-            
-            #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
-            
-            #line default
-            #line hidden
-            this.Write(".");
+            this.Write("            \"");
             
             #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
             
             #line default
             #line hidden
-            this.Write(") => true,\r\n");
+            this.Write("\" => true,\r\n");
             
             #line 75 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\src\EnumUtilities\CodeWriters\EnumValidationWriter.tt"
 

--- a/src/EnumUtilities/CodeWriters/EnumValidationWriter.tt
+++ b/src/EnumUtilities/CodeWriters/EnumValidationWriter.tt
@@ -26,13 +26,13 @@ using System.Diagnostics.CodeAnalysis;
     /// <returns><c>true</c> if the value of <see cref="<#= Model.Name #>"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
     public static bool IsDefined(<#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#
     foreach (var curr in Model.UniqueValues)
     {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => true,
+            <#= curr.MemberValue #> => true,
 <#
     }
 #>
@@ -50,7 +50,7 @@ using System.Diagnostics.CodeAnalysis;
     foreach (var curr in Model.Values)
     {
 #>
-            { } s when s.Equals(nameof(<#= Model.RefName #>.<#= curr.MemberName #>), comparisonType) => true,
+            { } s when s.Equals("<#= curr.MemberName #>", comparisonType) => true,
 <#
     }
 #>
@@ -71,7 +71,7 @@ using System.Diagnostics.CodeAnalysis;
     foreach (var curr in Model.Values)
     {
 #>
-            nameof(<#= Model.RefName #>.<#= curr.MemberName #>) => true,
+            "<#= curr.MemberName #>" => true,
 <#
     }
 #>

--- a/src/EnumUtilities/CodeWriters/Extensions/DefaultBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Extensions/DefaultBlock.ttinclude
@@ -6,13 +6,13 @@
     /// <returns>The string representation of the value of this instance.</returns>
     public static string ToStringFast(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
     foreach (var curr in Model.UniqueValues)
     {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => nameof(<#= Model.RefName #>.<#= curr.MemberName #>),
+            <#= curr.MemberValue #> => "<#= curr.MemberName #>",
 <#+
     }
 #>

--- a/src/EnumUtilities/CodeWriters/Extensions/DescriptionBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Extensions/DescriptionBlock.ttinclude
@@ -7,13 +7,13 @@
 
     public static string? GetDescription(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
         foreach (var curr in Model.UniqueValues.Where(x => x.Description != null))
         {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => "<#= curr.Description #>",
+            <#= curr.MemberValue #> => "<#= curr.Description #>",
 <#+
         }
 #>

--- a/src/EnumUtilities/CodeWriters/Extensions/DisplayBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Extensions/DisplayBlock.ttinclude
@@ -7,13 +7,13 @@
 
     public static string GetDisplayShortName(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
             foreach (var curr in Model.UniqueValues.Where(x => x.Display?.ShortName != null))
             {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => <#= curr.Display!.ResourceShortName != null
+            <#= curr.MemberValue #> => <#= curr.Display!.ResourceShortName != null
                                                                    ? Append(curr.Display.ResourceShortName)
                                                                    : Append($"\"{curr.Display.ShortName}\"") #>,
 <#+
@@ -25,18 +25,18 @@
 
     public static string GetDisplayName(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
             foreach (var curr in Model.UniqueValues)
             {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => <#=
+            <#= curr.MemberValue #> => <#=
                         curr.Display?.ResourceName != null
                             ? Append(curr.Display.ResourceName)
                             : curr.Display?.Name != null
                                 ? Append($"\"{curr.Display.Name}\"")
-                                : Append($"nameof({Model.RefName}.{curr.MemberName})") #>,
+                                : Append($"\"{curr.MemberName}\"") #>,
 <#+
             }
 #>
@@ -53,13 +53,13 @@
 
     public static string? GetDescription(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
             foreach (var curr in Model.UniqueValues.Where(x => x.Display?.Description != null))
             {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => <#=
+            <#= curr.MemberValue #> => <#=
                         curr.Display!.ResourceDescription != null
                             ? Append(curr.Display.ResourceDescription)
                             : Append($"\"{curr.Display.Description}\"") #>,

--- a/src/EnumUtilities/CodeWriters/Extensions/EnumMemberBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Extensions/EnumMemberBlock.ttinclude
@@ -7,16 +7,16 @@
 
     public static string ToEnumMemberValue(this <#= Model.RefName #> value)
     {
-        return value switch
+        return (<#= Model.UnderlyingType #>)value switch
         {
 <#+
         foreach (var curr in Model.UniqueValues)
         {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #> => <#=
+            <#= curr.MemberValue #> => <#=
                     curr.SerializationValue != null
                         ? Append($"\"{curr.SerializationValue}\"")
-                        : Append($"nameof({Model.RefName}.{curr.MemberName})") #>,
+                        : Append($"\"{curr.MemberName}\"") #>,
 <#+
         }
 #>

--- a/src/EnumUtilities/CodeWriters/Factory/DefaultBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/DefaultBlock.ttinclude
@@ -43,8 +43,7 @@
 <#+
             }
 #>
-            case { } s when TryParseNumeric(s, comparisonType, out <#= Model.UnderlyingType #> val):
-                numValue = val;
+            case { } s when TryParseNumeric(s, comparisonType, out numValue):
                 break;
             default:
                 return Enum.TryParse(name, out result);
@@ -95,8 +94,7 @@
 <#+
             }
 #>
-            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out <#= Model.UnderlyingType #> val):
-                numValue = val;
+            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                 break;
             default:
                 return Enum.TryParse(name, out result);

--- a/src/EnumUtilities/CodeWriters/Factory/DefaultBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/DefaultBlock.ttinclude
@@ -20,24 +20,41 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+        if (Model.Values.Count == 0)
+        {
+#>
+        return Enum.TryParse(name, out result);
+<#+
+        }
+        else
+        {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (name)
         {
 <#+
-    foreach (var curr in Model.Values)
-    {
+            foreach (var curr in Model.Values)
+            {
 #>
-            case { } s when s.Equals(nameof(<#= Model.RefName #>.<#= curr.MemberName #>), comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+            case { } s when s.Equals("<#= curr.MemberName #>", comparisonType):
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-    }
+            }
 #>
             case { } s when TryParseNumeric(s, comparisonType, out <#= Model.UnderlyingType #> val):
-                result = (<#= Model.RefName #>)val;
-                return true;
+                numValue = val;
+                break;
             default:
                 return Enum.TryParse(name, out result);
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+        }
+#>
     }
 
     /// <summary>
@@ -55,24 +72,41 @@
         [NotNullWhen(true)] string? name,
         out <#= Model.RefName #> result)
     {
+<#+
+        if (Model.Values.Count == 0)
+        {
+#>
+        return Enum.TryParse(name, out result);
+<#+
+        }
+        else
+        {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (name)
         {
 <#+
-    foreach (var curr in Model.Values)
-    {
+            foreach (var curr in Model.Values)
+            {
 #>
-            case nameof(<#= Model.RefName #>.<#= curr.MemberName #>):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+            case "<#= curr.MemberName #>":
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-    }
+            }
 #>
             case { } s when TryParseNumeric(s, StringComparison.Ordinal, out <#= Model.UnderlyingType #> val):
-                result = (<#= Model.RefName #>)val;
-                return true;
+                numValue = val;
+                break;
             default:
                 return Enum.TryParse(name, out result);
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+        }
+#>
     }
 
     /// <summary>

--- a/src/EnumUtilities/CodeWriters/Factory/DescriptionBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/DescriptionBlock.ttinclude
@@ -10,22 +10,40 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+        if (Model.Values.All(x => x.Description == null))
+        {
+#>
+        result = default;
+        return false;
+<#+
+        }
+        else
+        {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (description)
         {
 <#+
-        foreach (var curr in Model.Values.Where(x => x.Description != null))
-        {
+            foreach (var curr in Model.Values.Where(x => x.Description != null))
+            {
 #>
             case { } s when s.Equals("<#= curr.Description #>", comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-        }
+            }
 #>
             default:
                 result = default;
                 return false;
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+        }
+#>
     }
 
     public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out <#= Model.RefName #> result)

--- a/src/EnumUtilities/CodeWriters/Factory/DisplayBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/DisplayBlock.ttinclude
@@ -10,24 +10,41 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+            if (Model.Values.All(x => x.Display?.ShortName == null))
+            {
+#>
+        return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
+<#+
+            }
+            else
+            {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (displayShortName)
         {
 <#+
-            foreach (var curr in Model.Values.Where(x => x.Display?.ShortName != null))
-            {
+                foreach (var curr in Model.Values.Where(x => x.Display?.ShortName != null))
+                {
 #>
             case { } s when s.Equals(<#=
-                        curr.Display!.ResourceShortName != null
-                            ? Append(curr.Display.ResourceShortName)
-                            : Append($"\"{curr.Display.ShortName}\"") #>, comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+                            curr.Display!.ResourceShortName != null
+                                ? Append(curr.Display.ResourceShortName)
+                                : Append($"\"{curr.Display.ShortName}\"") #>, comparisonType):
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-            }
+                }
 #>
             default:
                 return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+            }
+#>
     }
 
     public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out <#= Model.RefName #> result)
@@ -50,27 +67,45 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+            if (Model.Values.Count == 0)
+            {
+#>
+        result = default;
+        return false;
+<#+
+            }
+            else
+            {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (displayName)
         {
 <#+
-            foreach (var curr in Model.Values)
-            {
+                foreach (var curr in Model.Values)
+                {
 #>
             case { } s when s.Equals(<#=
-                        curr.Display?.ResourceName != null
-                            ? Append(curr.Display.ResourceName)
-                            : curr.Display?.Name != null
-                                ? Append($"\"{curr.Display.Name}\"")
-                                : Append($"nameof({Model.RefName}.{curr.MemberName})") #>, comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+                            curr.Display?.ResourceName != null
+                                ? Append(curr.Display.ResourceName)
+                                : curr.Display?.Name != null
+                                    ? Append($"\"{curr.Display.Name}\"")
+                                    : Append($"\"{curr.MemberName}\"") #>, comparisonType):
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-            }
+                }
 #>
             default:
                 result = default;
                 return false;
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+            }
+#>
     }
 
     public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out <#= Model.RefName #> result)
@@ -100,25 +135,43 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+            if (Model.Values.All(x => x.Display?.Description == null))
+            {
+#>
+        result = default;
+        return false;
+<#+
+            }
+            else
+            {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (description)
         {
 <#+
-            foreach (var curr in Model.Values.Where(x => x.Display?.Description != null))
-            {
+                foreach (var curr in Model.Values.Where(x => x.Display?.Description != null))
+                {
 #>
             case { } s when s.Equals(<#=
-                        curr.Display!.ResourceDescription != null
-                            ? Append(curr.Display.ResourceDescription)
-                            : Append($"\"{curr.Display.Description}\"") #>, comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+                            curr.Display!.ResourceDescription != null
+                                ? Append(curr.Display.ResourceDescription)
+                                : Append($"\"{curr.Display.Description}\"") #>, comparisonType):
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-            }
+                }
 #>
             default:
                 result = default;
                 return false;
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+            }
+#>
     }
 
     public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out <#= Model.RefName #> result)

--- a/src/EnumUtilities/CodeWriters/Factory/EnumMemberBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/EnumMemberBlock.ttinclude
@@ -23,25 +23,43 @@
         StringComparison comparisonType,
         out <#= Model.RefName #> result)
     {
+<#+
+        if (Model.Values.Count == 0)
+        {
+#>
+        result = default;
+        return false;
+<#+
+        }
+        else
+        {
+#>
+        <#= Model.UnderlyingType #> numValue;
         switch (enumMemberValue)
         {
 <#+
-        foreach (var curr in Model.Values)
-        {
+            foreach (var curr in Model.Values)
+            {
 #>
             case { } s when s.Equals(<#=
-                    curr.SerializationValue != null
-                        ? Append($"\"{curr.SerializationValue}\"")
-                        : Append($"nameof({Model.RefName}.{curr.MemberName})") #>, comparisonType):
-                result = <#= Model.RefName #>.<#= curr.MemberName #>;
-                return true;
+                        curr.SerializationValue != null
+                            ? Append($"\"{curr.SerializationValue}\"")
+                            : Append($"\"{curr.MemberName}\"") #>, comparisonType):
+                numValue = <#= curr.MemberValue #>;
+                break;
 <#+
-        }
+            }
 #>
             default:
                 result = default;
                 return false;
         }
+
+        result = (<#= Model.RefName #>)numValue;
+        return true;
+<#+
+        }
+#>
     }
 
     /// <summary>

--- a/src/EnumUtilities/CodeWriters/Factory/MiscellaneousBlock.ttinclude
+++ b/src/EnumUtilities/CodeWriters/Factory/MiscellaneousBlock.ttinclude
@@ -13,7 +13,7 @@
     foreach (var curr in Model.UniqueValues)
     {
 #>
-            <#= Model.RefName #>.<#= curr.MemberName #>,
+            (<#= Model.RefName #>)<#= curr.MemberValue #>,
 <#+
     }
 #>
@@ -30,7 +30,7 @@
     foreach (var curr in Model.Values)
     {
 #>
-            nameof(<#= Model.RefName #>.<#= curr.MemberName #>),
+            "<#= curr.MemberName #>",
 <#+
     }
 #>

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.BigErrorCodeJsonConverter.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.BigErrorCodeJsonConverter.g.cs
@@ -11,22 +11,22 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 {
     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Raiqub.Generators.EnumUtilities", "1.6.0.0")]
-    internal sealed class ErrorCodeJsonConverter : JsonConverter<ErrorCode>
+    internal sealed class BigErrorCodeJsonConverter : JsonConverter<BigErrorCode>
     {
         private const int MaxBytesLength = 3;
         private const int MaxCharsLength = 3;
 
-        public override ErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override BigErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.String)
-                return (ErrorCode)ReadFromString(ref reader);
+                return (BigErrorCode)ReadFromString(ref reader);
 
-            return (ErrorCode)0;
+            return (BigErrorCode)0;
         }
 
-        public override void Write(Utf8JsonWriter writer, ErrorCode value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, BigErrorCode value, JsonSerializerOptions options)
         {
-            switch ((ushort)value)
+            switch ((ulong)value)
             {
                 case 0:
                     writer.WriteStringValue("NON"u8);
@@ -37,7 +37,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case 100:
                     writer.WriteStringValue("CNX"u8);
                     break;
-                case 200:
+                case 200000000000:
                     writer.WriteStringValue("OUT"u8);
                     break;
                 default:
@@ -46,12 +46,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             }
         }
 
-        private ushort ReadFromString(ref Utf8JsonReader reader)
+        private ulong ReadFromString(ref Utf8JsonReader reader)
         {
     #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
             if (length > MaxBytesLength)
-                return (ushort)0;
+                return 0;
 
             Span<char> name = stackalloc char[MaxBytesLength];
             int charsWritten = reader.CopyString(name);
@@ -62,11 +62,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
             return name switch
             {
-                "NON" => (ushort)0,
-                "UNK" => (ushort)1,
-                "CNX" => (ushort)100,
-                "OUT" => (ushort)200,
-                _ => Enum.TryParse(name, out ErrorCode result) ? (ushort)result : (ushort)0
+                "NON" => 0,
+                "UNK" => 1,
+                "CNX" => 100,
+                "OUT" => 200000000000,
+                _ => Enum.TryParse(name, out BigErrorCode result) ? (ulong)result : 0
             };
         }
     }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesExtensions.g.cs
@@ -17,14 +17,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this Categories value)
         {
-            return value switch
+            return (int)value switch
             {
-                Categories.Electronics => nameof(Categories.Electronics),
-                Categories.Food => nameof(Categories.Food),
-                Categories.Automotive => nameof(Categories.Automotive),
-                Categories.Arts => nameof(Categories.Arts),
-                Categories.BeautyCare => nameof(Categories.BeautyCare),
-                Categories.Fashion => nameof(Categories.Fashion),
+                0 => "Electronics",
+                1 => "Food",
+                2 => "Automotive",
+                3 => "Arts",
+                4 => "BeautyCare",
+                5 => "Fashion",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
@@ -52,8 +52,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Fashion", comparisonType):
                     numValue = 5;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -99,8 +98,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Fashion":
                     numValue = 5;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
@@ -31,32 +31,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out Categories result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(Categories.Electronics), comparisonType):
-                    result = Categories.Electronics;
-                    return true;
-                case { } s when s.Equals(nameof(Categories.Food), comparisonType):
-                    result = Categories.Food;
-                    return true;
-                case { } s when s.Equals(nameof(Categories.Automotive), comparisonType):
-                    result = Categories.Automotive;
-                    return true;
-                case { } s when s.Equals(nameof(Categories.Arts), comparisonType):
-                    result = Categories.Arts;
-                    return true;
-                case { } s when s.Equals(nameof(Categories.BeautyCare), comparisonType):
-                    result = Categories.BeautyCare;
-                    return true;
-                case { } s when s.Equals(nameof(Categories.Fashion), comparisonType):
-                    result = Categories.Fashion;
-                    return true;
+                case { } s when s.Equals("Electronics", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Food", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Automotive", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Arts", comparisonType):
+                    numValue = 3;
+                    break;
+                case { } s when s.Equals("BeautyCare", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Fashion", comparisonType):
+                    numValue = 5;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (Categories)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (Categories)numValue;
+            return true;
         }
 
         /// <summary>
@@ -74,32 +78,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out Categories result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(Categories.Electronics):
-                    result = Categories.Electronics;
-                    return true;
-                case nameof(Categories.Food):
-                    result = Categories.Food;
-                    return true;
-                case nameof(Categories.Automotive):
-                    result = Categories.Automotive;
-                    return true;
-                case nameof(Categories.Arts):
-                    result = Categories.Arts;
-                    return true;
-                case nameof(Categories.BeautyCare):
-                    result = Categories.BeautyCare;
-                    return true;
-                case nameof(Categories.Fashion):
-                    result = Categories.Fashion;
-                    return true;
+                case "Electronics":
+                    numValue = 0;
+                    break;
+                case "Food":
+                    numValue = 1;
+                    break;
+                case "Automotive":
+                    numValue = 2;
+                    break;
+                case "Arts":
+                    numValue = 3;
+                    break;
+                case "BeautyCare":
+                    numValue = 4;
+                    break;
+                case "Fashion":
+                    numValue = 5;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (Categories)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (Categories)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,12 +178,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                Categories.Electronics,
-                Categories.Food,
-                Categories.Automotive,
-                Categories.Arts,
-                Categories.BeautyCare,
-                Categories.Fashion,
+                (Categories)0,
+                (Categories)1,
+                (Categories)2,
+                (Categories)3,
+                (Categories)4,
+                (Categories)5,
             };
         }
 
@@ -185,12 +193,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(Categories.Electronics),
-                nameof(Categories.Food),
-                nameof(Categories.Automotive),
-                nameof(Categories.Arts),
-                nameof(Categories.BeautyCare),
-                nameof(Categories.Fashion),
+                "Electronics",
+                "Food",
+                "Automotive",
+                "Arts",
+                "BeautyCare",
+                "Fashion",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesValidation.g.cs
@@ -16,14 +16,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="Categories"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(Categories value)
         {
-            return value switch
+            return (int)value switch
             {
-                Categories.Electronics => true,
-                Categories.Food => true,
-                Categories.Automotive => true,
-                Categories.Arts => true,
-                Categories.BeautyCare => true,
-                Categories.Fashion => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+                5 => true,
                 _ => false
             };
         }
@@ -34,12 +34,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(Categories.Electronics), comparisonType) => true,
-                { } s when s.Equals(nameof(Categories.Food), comparisonType) => true,
-                { } s when s.Equals(nameof(Categories.Automotive), comparisonType) => true,
-                { } s when s.Equals(nameof(Categories.Arts), comparisonType) => true,
-                { } s when s.Equals(nameof(Categories.BeautyCare), comparisonType) => true,
-                { } s when s.Equals(nameof(Categories.Fashion), comparisonType) => true,
+                { } s when s.Equals("Electronics", comparisonType) => true,
+                { } s when s.Equals("Food", comparisonType) => true,
+                { } s when s.Equals("Automotive", comparisonType) => true,
+                { } s when s.Equals("Arts", comparisonType) => true,
+                { } s when s.Equals("BeautyCare", comparisonType) => true,
+                { } s when s.Equals("Fashion", comparisonType) => true,
                 _ => false
             };
         }
@@ -53,12 +53,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(Categories.Electronics) => true,
-                nameof(Categories.Food) => true,
-                nameof(Categories.Automotive) => true,
-                nameof(Categories.Arts) => true,
-                nameof(Categories.BeautyCare) => true,
-                nameof(Categories.Fashion) => true,
+                "Electronics" => true,
+                "Food" => true,
+                "Automotive" => true,
+                "Arts" => true,
+                "BeautyCare" => true,
+                "Fashion" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursExtensions.g.cs
@@ -17,11 +17,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this Colours value)
         {
-            return value switch
+            return (int)value switch
             {
-                Colours.Red => nameof(Colours.Red),
-                Colours.Blue => nameof(Colours.Blue),
-                Colours.Green => nameof(Colours.Green),
+                1 => "Red",
+                2 => "Blue",
+                4 => "Green",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
@@ -31,23 +31,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out Colours result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(Colours.Red), comparisonType):
-                    result = Colours.Red;
-                    return true;
-                case { } s when s.Equals(nameof(Colours.Blue), comparisonType):
-                    result = Colours.Blue;
-                    return true;
-                case { } s when s.Equals(nameof(Colours.Green), comparisonType):
-                    result = Colours.Green;
-                    return true;
+                case { } s when s.Equals("Red", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Blue", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Green", comparisonType):
+                    numValue = 4;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (Colours)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (Colours)numValue;
+            return true;
         }
 
         /// <summary>
@@ -65,23 +69,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out Colours result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(Colours.Red):
-                    result = Colours.Red;
-                    return true;
-                case nameof(Colours.Blue):
-                    result = Colours.Blue;
-                    return true;
-                case nameof(Colours.Green):
-                    result = Colours.Green;
-                    return true;
+                case "Red":
+                    numValue = 1;
+                    break;
+                case "Blue":
+                    numValue = 2;
+                    break;
+                case "Green":
+                    numValue = 4;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (Colours)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (Colours)numValue;
+            return true;
         }
 
         /// <summary>
@@ -152,9 +160,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                Colours.Red,
-                Colours.Blue,
-                Colours.Green,
+                (Colours)1,
+                (Colours)2,
+                (Colours)4,
             };
         }
 
@@ -164,9 +172,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(Colours.Red),
-                nameof(Colours.Blue),
-                nameof(Colours.Green),
+                "Red",
+                "Blue",
+                "Green",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
@@ -43,8 +43,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Green", comparisonType):
                     numValue = 4;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -81,8 +80,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Green":
                     numValue = 4;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursValidation.g.cs
@@ -16,11 +16,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="Colours"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(Colours value)
         {
-            return value switch
+            return (int)value switch
             {
-                Colours.Red => true,
-                Colours.Blue => true,
-                Colours.Green => true,
+                1 => true,
+                2 => true,
+                4 => true,
                 _ => false
             };
         }
@@ -31,9 +31,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(Colours.Red), comparisonType) => true,
-                { } s when s.Equals(nameof(Colours.Blue), comparisonType) => true,
-                { } s when s.Equals(nameof(Colours.Green), comparisonType) => true,
+                { } s when s.Equals("Red", comparisonType) => true,
+                { } s when s.Equals("Blue", comparisonType) => true,
+                { } s when s.Equals("Green", comparisonType) => true,
                 _ => false
             };
         }
@@ -47,9 +47,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(Colours.Red) => true,
-                nameof(Colours.Blue) => true,
-                nameof(Colours.Green) => true,
+                "Red" => true,
+                "Blue" => true,
+                "Green" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
@@ -21,7 +21,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             if (reader.TokenType == JsonTokenType.String)
                 return (ErrorCode)ReadFromString(ref reader);
 
-            return (ushort)0;
+            return (ErrorCode)(ushort)0;
         }
 
         public override void Write(Utf8JsonWriter writer, ErrorCode value, JsonSerializerOptions options)

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
@@ -19,25 +19,25 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         public override ErrorCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.String)
-                return ReadFromString(ref reader);
+                return (ErrorCode)ReadFromString(ref reader);
 
-            return (ErrorCode)0;
+            return (ushort)0;
         }
 
         public override void Write(Utf8JsonWriter writer, ErrorCode value, JsonSerializerOptions options)
         {
-            switch (value)
+            switch ((ushort)value)
             {
-                case ErrorCode.None:
+                case 0:
                     writer.WriteStringValue("NON"u8);
                     break;
-                case ErrorCode.Unknown:
+                case 1:
                     writer.WriteStringValue("UNK"u8);
                     break;
-                case ErrorCode.ConnectionLost:
+                case 100:
                     writer.WriteStringValue("CNX"u8);
                     break;
-                case ErrorCode.OutlierReading:
+                case 200:
                     writer.WriteStringValue("OUT"u8);
                     break;
                 default:
@@ -46,12 +46,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             }
         }
 
-        private ErrorCode ReadFromString(ref Utf8JsonReader reader)
+        private ushort ReadFromString(ref Utf8JsonReader reader)
         {
     #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
             if (length > MaxBytesLength)
-                return (ErrorCode)0;
+                return (ushort)0;
 
             Span<char> name = stackalloc char[MaxBytesLength];
             int charsWritten = reader.CopyString(name);
@@ -62,11 +62,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
             return name switch
             {
-                "NON" => ErrorCode.None,
-                "UNK" => ErrorCode.Unknown,
-                "CNX" => ErrorCode.ConnectionLost,
-                "OUT" => ErrorCode.OutlierReading,
-                _ => Enum.TryParse(name, out ErrorCode result) ? result : (ErrorCode)0
+                "NON" => (ushort)0,
+                "UNK" => (ushort)1,
+                "CNX" => (ushort)100,
+                "OUT" => (ushort)200,
+                _ => Enum.TryParse(name, out ErrorCode result) ? (ushort)result : (ushort)0
             };
         }
     }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesExtensions.g.cs
@@ -17,13 +17,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this HumanStates value)
         {
-            return value switch
+            return (int)value switch
             {
-                HumanStates.Idle => nameof(HumanStates.Idle),
-                HumanStates.Working => nameof(HumanStates.Working),
-                HumanStates.Sleeping => nameof(HumanStates.Sleeping),
-                HumanStates.Eating => nameof(HumanStates.Eating),
-                HumanStates.Dead => nameof(HumanStates.Dead),
+                1 => "Idle",
+                2 => "Working",
+                3 => "Sleeping",
+                4 => "Eating",
+                5 => "Dead",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
@@ -31,32 +31,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out HumanStates result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(HumanStates.Idle), comparisonType):
-                    result = HumanStates.Idle;
-                    return true;
-                case { } s when s.Equals(nameof(HumanStates.Working), comparisonType):
-                    result = HumanStates.Working;
-                    return true;
-                case { } s when s.Equals(nameof(HumanStates.Sleeping), comparisonType):
-                    result = HumanStates.Sleeping;
-                    return true;
-                case { } s when s.Equals(nameof(HumanStates.Eating), comparisonType):
-                    result = HumanStates.Eating;
-                    return true;
-                case { } s when s.Equals(nameof(HumanStates.Dead), comparisonType):
-                    result = HumanStates.Dead;
-                    return true;
-                case { } s when s.Equals(nameof(HumanStates.Relaxing), comparisonType):
-                    result = HumanStates.Relaxing;
-                    return true;
+                case { } s when s.Equals("Idle", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Working", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Sleeping", comparisonType):
+                    numValue = 3;
+                    break;
+                case { } s when s.Equals("Eating", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Dead", comparisonType):
+                    numValue = 5;
+                    break;
+                case { } s when s.Equals("Relaxing", comparisonType):
+                    numValue = 1;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (HumanStates)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (HumanStates)numValue;
+            return true;
         }
 
         /// <summary>
@@ -74,32 +78,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out HumanStates result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(HumanStates.Idle):
-                    result = HumanStates.Idle;
-                    return true;
-                case nameof(HumanStates.Working):
-                    result = HumanStates.Working;
-                    return true;
-                case nameof(HumanStates.Sleeping):
-                    result = HumanStates.Sleeping;
-                    return true;
-                case nameof(HumanStates.Eating):
-                    result = HumanStates.Eating;
-                    return true;
-                case nameof(HumanStates.Dead):
-                    result = HumanStates.Dead;
-                    return true;
-                case nameof(HumanStates.Relaxing):
-                    result = HumanStates.Relaxing;
-                    return true;
+                case "Idle":
+                    numValue = 1;
+                    break;
+                case "Working":
+                    numValue = 2;
+                    break;
+                case "Sleeping":
+                    numValue = 3;
+                    break;
+                case "Eating":
+                    numValue = 4;
+                    break;
+                case "Dead":
+                    numValue = 5;
+                    break;
+                case "Relaxing":
+                    numValue = 1;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (HumanStates)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (HumanStates)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,11 +178,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                HumanStates.Idle,
-                HumanStates.Working,
-                HumanStates.Sleeping,
-                HumanStates.Eating,
-                HumanStates.Dead,
+                (HumanStates)1,
+                (HumanStates)2,
+                (HumanStates)3,
+                (HumanStates)4,
+                (HumanStates)5,
             };
         }
 
@@ -184,12 +192,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(HumanStates.Idle),
-                nameof(HumanStates.Working),
-                nameof(HumanStates.Sleeping),
-                nameof(HumanStates.Eating),
-                nameof(HumanStates.Dead),
-                nameof(HumanStates.Relaxing),
+                "Idle",
+                "Working",
+                "Sleeping",
+                "Eating",
+                "Dead",
+                "Relaxing",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
@@ -52,8 +52,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Relaxing", comparisonType):
                     numValue = 1;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -99,8 +98,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Relaxing":
                     numValue = 1;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesValidation.g.cs
@@ -16,13 +16,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="HumanStates"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(HumanStates value)
         {
-            return value switch
+            return (int)value switch
             {
-                HumanStates.Idle => true,
-                HumanStates.Working => true,
-                HumanStates.Sleeping => true,
-                HumanStates.Eating => true,
-                HumanStates.Dead => true,
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+                5 => true,
                 _ => false
             };
         }
@@ -33,12 +33,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(HumanStates.Idle), comparisonType) => true,
-                { } s when s.Equals(nameof(HumanStates.Working), comparisonType) => true,
-                { } s when s.Equals(nameof(HumanStates.Sleeping), comparisonType) => true,
-                { } s when s.Equals(nameof(HumanStates.Eating), comparisonType) => true,
-                { } s when s.Equals(nameof(HumanStates.Dead), comparisonType) => true,
-                { } s when s.Equals(nameof(HumanStates.Relaxing), comparisonType) => true,
+                { } s when s.Equals("Idle", comparisonType) => true,
+                { } s when s.Equals("Working", comparisonType) => true,
+                { } s when s.Equals("Sleeping", comparisonType) => true,
+                { } s when s.Equals("Eating", comparisonType) => true,
+                { } s when s.Equals("Dead", comparisonType) => true,
+                { } s when s.Equals("Relaxing", comparisonType) => true,
                 _ => false
             };
         }
@@ -52,12 +52,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(HumanStates.Idle) => true,
-                nameof(HumanStates.Working) => true,
-                nameof(HumanStates.Sleeping) => true,
-                nameof(HumanStates.Eating) => true,
-                nameof(HumanStates.Dead) => true,
-                nameof(HumanStates.Relaxing) => true,
+                "Idle" => true,
+                "Working" => true,
+                "Sleeping" => true,
+                "Eating" => true,
+                "Dead" => true,
+                "Relaxing" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Extensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Extensions.g.cs
@@ -17,11 +17,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this NestedInClass.MyEnum1 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum1.Zero => nameof(NestedInClass.MyEnum1.Zero),
-                NestedInClass.MyEnum1.One => nameof(NestedInClass.MyEnum1.One),
-                NestedInClass.MyEnum1.Two => nameof(NestedInClass.MyEnum1.Two),
+                0 => "Zero",
+                1 => "One",
+                2 => "Two",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
@@ -43,8 +43,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Two", comparisonType):
                     numValue = 2;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -81,8 +80,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Two":
                     numValue = 2;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
@@ -31,23 +31,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum1 result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum1.Zero), comparisonType):
-                    result = NestedInClass.MyEnum1.Zero;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum1.One), comparisonType):
-                    result = NestedInClass.MyEnum1.One;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum1.Two), comparisonType):
-                    result = NestedInClass.MyEnum1.Two;
-                    return true;
+                case { } s when s.Equals("Zero", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("One", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Two", comparisonType):
+                    numValue = 2;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (NestedInClass.MyEnum1)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum1)numValue;
+            return true;
         }
 
         /// <summary>
@@ -65,23 +69,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out NestedInClass.MyEnum1 result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(NestedInClass.MyEnum1.Zero):
-                    result = NestedInClass.MyEnum1.Zero;
-                    return true;
-                case nameof(NestedInClass.MyEnum1.One):
-                    result = NestedInClass.MyEnum1.One;
-                    return true;
-                case nameof(NestedInClass.MyEnum1.Two):
-                    result = NestedInClass.MyEnum1.Two;
-                    return true;
+                case "Zero":
+                    numValue = 0;
+                    break;
+                case "One":
+                    numValue = 1;
+                    break;
+                case "Two":
+                    numValue = 2;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (NestedInClass.MyEnum1)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum1)numValue;
+            return true;
         }
 
         /// <summary>
@@ -152,9 +160,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                NestedInClass.MyEnum1.Zero,
-                NestedInClass.MyEnum1.One,
-                NestedInClass.MyEnum1.Two,
+                (NestedInClass.MyEnum1)0,
+                (NestedInClass.MyEnum1)1,
+                (NestedInClass.MyEnum1)2,
             };
         }
 
@@ -164,9 +172,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(NestedInClass.MyEnum1.Zero),
-                nameof(NestedInClass.MyEnum1.One),
-                nameof(NestedInClass.MyEnum1.Two),
+                "Zero",
+                "One",
+                "Two",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Validation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Validation.g.cs
@@ -16,11 +16,11 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="MyEnum1"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(NestedInClass.MyEnum1 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum1.Zero => true,
-                NestedInClass.MyEnum1.One => true,
-                NestedInClass.MyEnum1.Two => true,
+                0 => true,
+                1 => true,
+                2 => true,
                 _ => false
             };
         }
@@ -31,9 +31,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(NestedInClass.MyEnum1.Zero), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum1.One), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum1.Two), comparisonType) => true,
+                { } s when s.Equals("Zero", comparisonType) => true,
+                { } s when s.Equals("One", comparisonType) => true,
+                { } s when s.Equals("Two", comparisonType) => true,
                 _ => false
             };
         }
@@ -47,9 +47,9 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(NestedInClass.MyEnum1.Zero) => true,
-                nameof(NestedInClass.MyEnum1.One) => true,
-                nameof(NestedInClass.MyEnum1.Two) => true,
+                "Zero" => true,
+                "One" => true,
+                "Two" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Extensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Extensions.g.cs
@@ -17,12 +17,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum2.Credit => nameof(NestedInClass.MyEnum2.Credit),
-                NestedInClass.MyEnum2.Debit => nameof(NestedInClass.MyEnum2.Debit),
-                NestedInClass.MyEnum2.Cash => nameof(NestedInClass.MyEnum2.Cash),
-                NestedInClass.MyEnum2.Cheque => nameof(NestedInClass.MyEnum2.Cheque),
+                0 => "Credit",
+                1 => "Debit",
+                2 => "Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }
@@ -90,28 +90,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string ToEnumMemberValue(this NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum2.Credit => "Credit card",
-                NestedInClass.MyEnum2.Debit => "Debit card",
-                NestedInClass.MyEnum2.Cash => nameof(NestedInClass.MyEnum2.Cash),
-                NestedInClass.MyEnum2.Cheque => nameof(NestedInClass.MyEnum2.Cheque),
+                0 => "Credit card",
+                1 => "Debit card",
+                2 => "Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }
 
         public static string? GetDescription(this NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum2.Cash => "The payment by using physical cash",
+                2 => "The payment by using physical cash",
                 _ => null
             };
         }
 
         public static string GetDisplayShortName(this NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
                 _ => GetDisplayName(value)
             };
@@ -119,12 +119,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string GetDisplayName(this NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum2.Credit => "Credit Card",
-                NestedInClass.MyEnum2.Debit => "Debit Card",
-                NestedInClass.MyEnum2.Cash => "Physical Cash",
-                NestedInClass.MyEnum2.Cheque => nameof(NestedInClass.MyEnum2.Cheque),
+                0 => "Credit Card",
+                1 => "Debit Card",
+                2 => "Physical Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
@@ -46,8 +46,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Cheque", comparisonType):
                     numValue = 3;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -87,8 +86,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Cheque":
                     numValue = 3;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
@@ -31,26 +31,30 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum2 result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Credit), comparisonType):
-                    result = NestedInClass.MyEnum2.Credit;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Debit), comparisonType):
-                    result = NestedInClass.MyEnum2.Debit;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cash), comparisonType):
-                    result = NestedInClass.MyEnum2.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cheque), comparisonType):
-                    result = NestedInClass.MyEnum2.Cheque;
-                    return true;
+                case { } s when s.Equals("Credit", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Debit", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Cash", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (NestedInClass.MyEnum2)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum2)numValue;
+            return true;
         }
 
         /// <summary>
@@ -68,26 +72,30 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out NestedInClass.MyEnum2 result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(NestedInClass.MyEnum2.Credit):
-                    result = NestedInClass.MyEnum2.Credit;
-                    return true;
-                case nameof(NestedInClass.MyEnum2.Debit):
-                    result = NestedInClass.MyEnum2.Debit;
-                    return true;
-                case nameof(NestedInClass.MyEnum2.Cash):
-                    result = NestedInClass.MyEnum2.Cash;
-                    return true;
-                case nameof(NestedInClass.MyEnum2.Cheque):
-                    result = NestedInClass.MyEnum2.Cheque;
-                    return true;
+                case "Credit":
+                    numValue = 0;
+                    break;
+                case "Debit":
+                    numValue = 1;
+                    break;
+                case "Cash":
+                    numValue = 2;
+                    break;
+                case "Cheque":
+                    numValue = 3;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (NestedInClass.MyEnum2)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum2)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,24 +178,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum2 result)
         {
+            int numValue;
             switch (enumMemberValue)
             {
                 case { } s when s.Equals("Credit card", comparisonType):
-                    result = NestedInClass.MyEnum2.Credit;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Debit card", comparisonType):
-                    result = NestedInClass.MyEnum2.Debit;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cash), comparisonType):
-                    result = NestedInClass.MyEnum2.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cheque), comparisonType):
-                    result = NestedInClass.MyEnum2.Cheque;
-                    return true;
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Cash", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (NestedInClass.MyEnum2)numValue;
+            return true;
         }
 
         /// <summary>
@@ -241,15 +253,19 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum2 result)
         {
+            int numValue;
             switch (description)
             {
                 case { } s when s.Equals("The payment by using physical cash", comparisonType):
-                    result = NestedInClass.MyEnum2.Cash;
-                    return true;
+                    numValue = 2;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (NestedInClass.MyEnum2)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out NestedInClass.MyEnum2 result)
@@ -272,11 +288,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum2 result)
         {
-            switch (displayShortName)
-            {
-                default:
-                    return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
-            }
+            return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
         }
 
         public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out NestedInClass.MyEnum2 result)
@@ -299,24 +311,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum2 result)
         {
+            int numValue;
             switch (displayName)
             {
                 case { } s when s.Equals("Credit Card", comparisonType):
-                    result = NestedInClass.MyEnum2.Credit;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Debit Card", comparisonType):
-                    result = NestedInClass.MyEnum2.Debit;
-                    return true;
+                    numValue = 1;
+                    break;
                 case { } s when s.Equals("Physical Cash", comparisonType):
-                    result = NestedInClass.MyEnum2.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cheque), comparisonType):
-                    result = NestedInClass.MyEnum2.Cheque;
-                    return true;
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (NestedInClass.MyEnum2)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out NestedInClass.MyEnum2 result)
@@ -340,10 +356,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                NestedInClass.MyEnum2.Credit,
-                NestedInClass.MyEnum2.Debit,
-                NestedInClass.MyEnum2.Cash,
-                NestedInClass.MyEnum2.Cheque,
+                (NestedInClass.MyEnum2)0,
+                (NestedInClass.MyEnum2)1,
+                (NestedInClass.MyEnum2)2,
+                (NestedInClass.MyEnum2)3,
             };
         }
 
@@ -353,10 +369,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(NestedInClass.MyEnum2.Credit),
-                nameof(NestedInClass.MyEnum2.Debit),
-                nameof(NestedInClass.MyEnum2.Cash),
-                nameof(NestedInClass.MyEnum2.Cheque),
+                "Credit",
+                "Debit",
+                "Cash",
+                "Cheque",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Validation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Validation.g.cs
@@ -16,12 +16,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="MyEnum2"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(NestedInClass.MyEnum2 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum2.Credit => true,
-                NestedInClass.MyEnum2.Debit => true,
-                NestedInClass.MyEnum2.Cash => true,
-                NestedInClass.MyEnum2.Cheque => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
                 _ => false
             };
         }
@@ -32,10 +32,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(NestedInClass.MyEnum2.Credit), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum2.Debit), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cash), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum2.Cheque), comparisonType) => true,
+                { } s when s.Equals("Credit", comparisonType) => true,
+                { } s when s.Equals("Debit", comparisonType) => true,
+                { } s when s.Equals("Cash", comparisonType) => true,
+                { } s when s.Equals("Cheque", comparisonType) => true,
                 _ => false
             };
         }
@@ -49,10 +49,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(NestedInClass.MyEnum2.Credit) => true,
-                nameof(NestedInClass.MyEnum2.Debit) => true,
-                nameof(NestedInClass.MyEnum2.Cash) => true,
-                nameof(NestedInClass.MyEnum2.Cheque) => true,
+                "Credit" => true,
+                "Debit" => true,
+                "Cash" => true,
+                "Cheque" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Extensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Extensions.g.cs
@@ -17,15 +17,15 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this NestedInClass.MyEnum3 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum3.Monday => nameof(NestedInClass.MyEnum3.Monday),
-                NestedInClass.MyEnum3.Tuesday => nameof(NestedInClass.MyEnum3.Tuesday),
-                NestedInClass.MyEnum3.Wednesday => nameof(NestedInClass.MyEnum3.Wednesday),
-                NestedInClass.MyEnum3.Thursday => nameof(NestedInClass.MyEnum3.Thursday),
-                NestedInClass.MyEnum3.Friday => nameof(NestedInClass.MyEnum3.Friday),
-                NestedInClass.MyEnum3.Saturday => nameof(NestedInClass.MyEnum3.Saturday),
-                NestedInClass.MyEnum3.Sunday => nameof(NestedInClass.MyEnum3.Sunday),
+                0 => "Monday",
+                1 => "Tuesday",
+                2 => "Wednesday",
+                3 => "Thursday",
+                4 => "Friday",
+                5 => "Saturday",
+                6 => "Sunday",
                 _ => value.ToString()
             };
         }
@@ -93,38 +93,38 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string GetDisplayShortName(this NestedInClass.MyEnum3 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum3.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort,
-                NestedInClass.MyEnum3.Tuesday => "Tue",
-                NestedInClass.MyEnum3.Friday => "Fri",
-                NestedInClass.MyEnum3.Saturday => "Sat",
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort,
+                1 => "Tue",
+                4 => "Fri",
+                5 => "Sat",
                 _ => GetDisplayName(value)
             };
         }
 
         public static string GetDisplayName(this NestedInClass.MyEnum3 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum3.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull,
-                NestedInClass.MyEnum3.Tuesday => nameof(NestedInClass.MyEnum3.Tuesday),
-                NestedInClass.MyEnum3.Wednesday => nameof(NestedInClass.MyEnum3.Wednesday),
-                NestedInClass.MyEnum3.Thursday => "Thursday",
-                NestedInClass.MyEnum3.Friday => "Friday",
-                NestedInClass.MyEnum3.Saturday => nameof(NestedInClass.MyEnum3.Saturday),
-                NestedInClass.MyEnum3.Sunday => nameof(NestedInClass.MyEnum3.Sunday),
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull,
+                1 => "Tuesday",
+                2 => "Wednesday",
+                3 => "Thursday",
+                4 => "Friday",
+                5 => "Saturday",
+                6 => "Sunday",
                 _ => value.ToString()
             };
         }
 
         public static string? GetDescription(this NestedInClass.MyEnum3 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum3.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription,
-                NestedInClass.MyEnum3.Saturday => "Almost the last day of the week",
-                NestedInClass.MyEnum3.Sunday => "The last day of the week",
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription,
+                5 => "Almost the last day of the week",
+                6 => "The last day of the week",
                 _ => null
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
@@ -31,35 +31,39 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum3 result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Monday), comparisonType):
-                    result = NestedInClass.MyEnum3.Monday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Tuesday), comparisonType):
-                    result = NestedInClass.MyEnum3.Tuesday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Wednesday), comparisonType):
-                    result = NestedInClass.MyEnum3.Wednesday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Thursday), comparisonType):
-                    result = NestedInClass.MyEnum3.Thursday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Friday), comparisonType):
-                    result = NestedInClass.MyEnum3.Friday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Saturday), comparisonType):
-                    result = NestedInClass.MyEnum3.Saturday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Sunday), comparisonType):
-                    result = NestedInClass.MyEnum3.Sunday;
-                    return true;
+                case { } s when s.Equals("Monday", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Tuesday", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Wednesday", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Thursday", comparisonType):
+                    numValue = 3;
+                    break;
+                case { } s when s.Equals("Friday", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Saturday", comparisonType):
+                    numValue = 5;
+                    break;
+                case { } s when s.Equals("Sunday", comparisonType):
+                    numValue = 6;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (NestedInClass.MyEnum3)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum3)numValue;
+            return true;
         }
 
         /// <summary>
@@ -77,35 +81,39 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out NestedInClass.MyEnum3 result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(NestedInClass.MyEnum3.Monday):
-                    result = NestedInClass.MyEnum3.Monday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Tuesday):
-                    result = NestedInClass.MyEnum3.Tuesday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Wednesday):
-                    result = NestedInClass.MyEnum3.Wednesday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Thursday):
-                    result = NestedInClass.MyEnum3.Thursday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Friday):
-                    result = NestedInClass.MyEnum3.Friday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Saturday):
-                    result = NestedInClass.MyEnum3.Saturday;
-                    return true;
-                case nameof(NestedInClass.MyEnum3.Sunday):
-                    result = NestedInClass.MyEnum3.Sunday;
-                    return true;
+                case "Monday":
+                    numValue = 0;
+                    break;
+                case "Tuesday":
+                    numValue = 1;
+                    break;
+                case "Wednesday":
+                    numValue = 2;
+                    break;
+                case "Thursday":
+                    numValue = 3;
+                    break;
+                case "Friday":
+                    numValue = 4;
+                    break;
+                case "Saturday":
+                    numValue = 5;
+                    break;
+                case "Sunday":
+                    numValue = 6;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (NestedInClass.MyEnum3)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (NestedInClass.MyEnum3)numValue;
+            return true;
         }
 
         /// <summary>
@@ -175,23 +183,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum3 result)
         {
+            int numValue;
             switch (displayShortName)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort, comparisonType):
-                    result = NestedInClass.MyEnum3.Monday;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Tue", comparisonType):
-                    result = NestedInClass.MyEnum3.Tuesday;
-                    return true;
+                    numValue = 1;
+                    break;
                 case { } s when s.Equals("Fri", comparisonType):
-                    result = NestedInClass.MyEnum3.Friday;
-                    return true;
+                    numValue = 4;
+                    break;
                 case { } s when s.Equals("Sat", comparisonType):
-                    result = NestedInClass.MyEnum3.Saturday;
-                    return true;
+                    numValue = 5;
+                    break;
                 default:
                     return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
             }
+
+            result = (NestedInClass.MyEnum3)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out NestedInClass.MyEnum3 result)
@@ -214,33 +226,37 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum3 result)
         {
+            int numValue;
             switch (displayName)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull, comparisonType):
-                    result = NestedInClass.MyEnum3.Monday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Tuesday), comparisonType):
-                    result = NestedInClass.MyEnum3.Tuesday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Wednesday), comparisonType):
-                    result = NestedInClass.MyEnum3.Wednesday;
-                    return true;
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Tuesday", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Wednesday", comparisonType):
+                    numValue = 2;
+                    break;
                 case { } s when s.Equals("Thursday", comparisonType):
-                    result = NestedInClass.MyEnum3.Thursday;
-                    return true;
+                    numValue = 3;
+                    break;
                 case { } s when s.Equals("Friday", comparisonType):
-                    result = NestedInClass.MyEnum3.Friday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Saturday), comparisonType):
-                    result = NestedInClass.MyEnum3.Saturday;
-                    return true;
-                case { } s when s.Equals(nameof(NestedInClass.MyEnum3.Sunday), comparisonType):
-                    result = NestedInClass.MyEnum3.Sunday;
-                    return true;
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Saturday", comparisonType):
+                    numValue = 5;
+                    break;
+                case { } s when s.Equals("Sunday", comparisonType):
+                    numValue = 6;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (NestedInClass.MyEnum3)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out NestedInClass.MyEnum3 result)
@@ -263,21 +279,25 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out NestedInClass.MyEnum3 result)
         {
+            int numValue;
             switch (description)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription, comparisonType):
-                    result = NestedInClass.MyEnum3.Monday;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Almost the last day of the week", comparisonType):
-                    result = NestedInClass.MyEnum3.Saturday;
-                    return true;
+                    numValue = 5;
+                    break;
                 case { } s when s.Equals("The last day of the week", comparisonType):
-                    result = NestedInClass.MyEnum3.Sunday;
-                    return true;
+                    numValue = 6;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (NestedInClass.MyEnum3)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out NestedInClass.MyEnum3 result)
@@ -301,13 +321,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                NestedInClass.MyEnum3.Monday,
-                NestedInClass.MyEnum3.Tuesday,
-                NestedInClass.MyEnum3.Wednesday,
-                NestedInClass.MyEnum3.Thursday,
-                NestedInClass.MyEnum3.Friday,
-                NestedInClass.MyEnum3.Saturday,
-                NestedInClass.MyEnum3.Sunday,
+                (NestedInClass.MyEnum3)0,
+                (NestedInClass.MyEnum3)1,
+                (NestedInClass.MyEnum3)2,
+                (NestedInClass.MyEnum3)3,
+                (NestedInClass.MyEnum3)4,
+                (NestedInClass.MyEnum3)5,
+                (NestedInClass.MyEnum3)6,
             };
         }
 
@@ -317,13 +337,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(NestedInClass.MyEnum3.Monday),
-                nameof(NestedInClass.MyEnum3.Tuesday),
-                nameof(NestedInClass.MyEnum3.Wednesday),
-                nameof(NestedInClass.MyEnum3.Thursday),
-                nameof(NestedInClass.MyEnum3.Friday),
-                nameof(NestedInClass.MyEnum3.Saturday),
-                nameof(NestedInClass.MyEnum3.Sunday),
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
@@ -55,8 +55,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Sunday", comparisonType):
                     numValue = 6;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -105,8 +104,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Sunday":
                     numValue = 6;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Validation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Validation.g.cs
@@ -16,15 +16,15 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="MyEnum3"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(NestedInClass.MyEnum3 value)
         {
-            return value switch
+            return (int)value switch
             {
-                NestedInClass.MyEnum3.Monday => true,
-                NestedInClass.MyEnum3.Tuesday => true,
-                NestedInClass.MyEnum3.Wednesday => true,
-                NestedInClass.MyEnum3.Thursday => true,
-                NestedInClass.MyEnum3.Friday => true,
-                NestedInClass.MyEnum3.Saturday => true,
-                NestedInClass.MyEnum3.Sunday => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+                5 => true,
+                6 => true,
                 _ => false
             };
         }
@@ -35,13 +35,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Monday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Tuesday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Wednesday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Thursday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Friday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Saturday), comparisonType) => true,
-                { } s when s.Equals(nameof(NestedInClass.MyEnum3.Sunday), comparisonType) => true,
+                { } s when s.Equals("Monday", comparisonType) => true,
+                { } s when s.Equals("Tuesday", comparisonType) => true,
+                { } s when s.Equals("Wednesday", comparisonType) => true,
+                { } s when s.Equals("Thursday", comparisonType) => true,
+                { } s when s.Equals("Friday", comparisonType) => true,
+                { } s when s.Equals("Saturday", comparisonType) => true,
+                { } s when s.Equals("Sunday", comparisonType) => true,
                 _ => false
             };
         }
@@ -55,13 +55,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(NestedInClass.MyEnum3.Monday) => true,
-                nameof(NestedInClass.MyEnum3.Tuesday) => true,
-                nameof(NestedInClass.MyEnum3.Wednesday) => true,
-                nameof(NestedInClass.MyEnum3.Thursday) => true,
-                nameof(NestedInClass.MyEnum3.Friday) => true,
-                nameof(NestedInClass.MyEnum3.Saturday) => true,
-                nameof(NestedInClass.MyEnum3.Sunday) => true,
+                "Monday" => true,
+                "Tuesday" => true,
+                "Wednesday" => true,
+                "Thursday" => true,
+                "Friday" => true,
+                "Saturday" => true,
+                "Sunday" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodExtensions.g.cs
@@ -17,12 +17,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
-                PaymentMethod.Credit => nameof(PaymentMethod.Credit),
-                PaymentMethod.Debit => nameof(PaymentMethod.Debit),
-                PaymentMethod.Cash => nameof(PaymentMethod.Cash),
-                PaymentMethod.Cheque => nameof(PaymentMethod.Cheque),
+                0 => "Credit",
+                1 => "Debit",
+                2 => "Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }
@@ -90,28 +90,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string ToEnumMemberValue(this PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
-                PaymentMethod.Credit => "Credit card",
-                PaymentMethod.Debit => "Debit card",
-                PaymentMethod.Cash => nameof(PaymentMethod.Cash),
-                PaymentMethod.Cheque => nameof(PaymentMethod.Cheque),
+                0 => "Credit card",
+                1 => "Debit card",
+                2 => "Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }
 
         public static string? GetDescription(this PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
-                PaymentMethod.Cash => "The payment by using physical cash",
+                2 => "The payment by using physical cash",
                 _ => null
             };
         }
 
         public static string GetDisplayShortName(this PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
                 _ => GetDisplayName(value)
             };
@@ -119,12 +119,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string GetDisplayName(this PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
-                PaymentMethod.Credit => "Credit Card",
-                PaymentMethod.Debit => "Debit Card",
-                PaymentMethod.Cash => "Physical Cash",
-                PaymentMethod.Cheque => nameof(PaymentMethod.Cheque),
+                0 => "Credit Card",
+                1 => "Debit Card",
+                2 => "Physical Cash",
+                3 => "Cheque",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
@@ -46,8 +46,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Cheque", comparisonType):
                     numValue = 3;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -87,8 +86,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Cheque":
                     numValue = 3;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
@@ -31,26 +31,30 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out PaymentMethod result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(PaymentMethod.Credit), comparisonType):
-                    result = PaymentMethod.Credit;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Debit), comparisonType):
-                    result = PaymentMethod.Debit;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Cash), comparisonType):
-                    result = PaymentMethod.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Cheque), comparisonType):
-                    result = PaymentMethod.Cheque;
-                    return true;
+                case { } s when s.Equals("Credit", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Debit", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Cash", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (PaymentMethod)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (PaymentMethod)numValue;
+            return true;
         }
 
         /// <summary>
@@ -68,26 +72,30 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out PaymentMethod result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(PaymentMethod.Credit):
-                    result = PaymentMethod.Credit;
-                    return true;
-                case nameof(PaymentMethod.Debit):
-                    result = PaymentMethod.Debit;
-                    return true;
-                case nameof(PaymentMethod.Cash):
-                    result = PaymentMethod.Cash;
-                    return true;
-                case nameof(PaymentMethod.Cheque):
-                    result = PaymentMethod.Cheque;
-                    return true;
+                case "Credit":
+                    numValue = 0;
+                    break;
+                case "Debit":
+                    numValue = 1;
+                    break;
+                case "Cash":
+                    numValue = 2;
+                    break;
+                case "Cheque":
+                    numValue = 3;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (PaymentMethod)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (PaymentMethod)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,24 +178,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out PaymentMethod result)
         {
+            int numValue;
             switch (enumMemberValue)
             {
                 case { } s when s.Equals("Credit card", comparisonType):
-                    result = PaymentMethod.Credit;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Debit card", comparisonType):
-                    result = PaymentMethod.Debit;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Cash), comparisonType):
-                    result = PaymentMethod.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Cheque), comparisonType):
-                    result = PaymentMethod.Cheque;
-                    return true;
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Cash", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (PaymentMethod)numValue;
+            return true;
         }
 
         /// <summary>
@@ -241,15 +253,19 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out PaymentMethod result)
         {
+            int numValue;
             switch (description)
             {
                 case { } s when s.Equals("The payment by using physical cash", comparisonType):
-                    result = PaymentMethod.Cash;
-                    return true;
+                    numValue = 2;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (PaymentMethod)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out PaymentMethod result)
@@ -272,11 +288,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out PaymentMethod result)
         {
-            switch (displayShortName)
-            {
-                default:
-                    return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
-            }
+            return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
         }
 
         public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out PaymentMethod result)
@@ -299,24 +311,28 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out PaymentMethod result)
         {
+            int numValue;
             switch (displayName)
             {
                 case { } s when s.Equals("Credit Card", comparisonType):
-                    result = PaymentMethod.Credit;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Debit Card", comparisonType):
-                    result = PaymentMethod.Debit;
-                    return true;
+                    numValue = 1;
+                    break;
                 case { } s when s.Equals("Physical Cash", comparisonType):
-                    result = PaymentMethod.Cash;
-                    return true;
-                case { } s when s.Equals(nameof(PaymentMethod.Cheque), comparisonType):
-                    result = PaymentMethod.Cheque;
-                    return true;
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Cheque", comparisonType):
+                    numValue = 3;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (PaymentMethod)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out PaymentMethod result)
@@ -340,10 +356,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                PaymentMethod.Credit,
-                PaymentMethod.Debit,
-                PaymentMethod.Cash,
-                PaymentMethod.Cheque,
+                (PaymentMethod)0,
+                (PaymentMethod)1,
+                (PaymentMethod)2,
+                (PaymentMethod)3,
             };
         }
 
@@ -353,10 +369,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(PaymentMethod.Credit),
-                nameof(PaymentMethod.Debit),
-                nameof(PaymentMethod.Cash),
-                nameof(PaymentMethod.Cheque),
+                "Credit",
+                "Debit",
+                "Cash",
+                "Cheque",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodValidation.g.cs
@@ -16,12 +16,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="PaymentMethod"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(PaymentMethod value)
         {
-            return value switch
+            return (int)value switch
             {
-                PaymentMethod.Credit => true,
-                PaymentMethod.Debit => true,
-                PaymentMethod.Cash => true,
-                PaymentMethod.Cheque => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
                 _ => false
             };
         }
@@ -32,10 +32,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(PaymentMethod.Credit), comparisonType) => true,
-                { } s when s.Equals(nameof(PaymentMethod.Debit), comparisonType) => true,
-                { } s when s.Equals(nameof(PaymentMethod.Cash), comparisonType) => true,
-                { } s when s.Equals(nameof(PaymentMethod.Cheque), comparisonType) => true,
+                { } s when s.Equals("Credit", comparisonType) => true,
+                { } s when s.Equals("Debit", comparisonType) => true,
+                { } s when s.Equals("Cash", comparisonType) => true,
+                { } s when s.Equals("Cheque", comparisonType) => true,
                 _ => false
             };
         }
@@ -49,10 +49,10 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(PaymentMethod.Credit) => true,
-                nameof(PaymentMethod.Debit) => true,
-                nameof(PaymentMethod.Cash) => true,
-                nameof(PaymentMethod.Cheque) => true,
+                "Credit" => true,
+                "Debit" => true,
+                "Cash" => true,
+                "Cheque" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SeasonJsonConverter.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SeasonJsonConverter.g.cs
@@ -19,27 +19,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         public override Season Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.String)
-                return ReadFromString(ref reader);
+                return (Season)ReadFromString(ref reader);
             if (reader.TokenType == JsonTokenType.Number)
-                return ReadFromNumber(ref reader);
+                return (Season)ReadFromNumber(ref reader);
 
             throw new JsonException();
         }
 
         public override void Write(Utf8JsonWriter writer, Season value, JsonSerializerOptions options)
         {
-            switch (value)
+            switch ((int)value)
             {
-                case Season.Spring:
+                case 1:
                     writer.WriteStringValue("🌱"u8);
                     break;
-                case Season.Summer:
+                case 2:
                     writer.WriteStringValue("☀️"u8);
                     break;
-                case Season.Autumn:
+                case 3:
                     writer.WriteStringValue("🍂"u8);
                     break;
-                case Season.Winter:
+                case 4:
                     writer.WriteStringValue("⛄"u8);
                     break;
                 default:
@@ -48,7 +48,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             }
         }
 
-        private Season ReadFromString(ref Utf8JsonReader reader)
+        private int ReadFromString(ref Utf8JsonReader reader)
         {
     #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
@@ -64,18 +64,18 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
             return name switch
             {
-                "🌱" => Season.Spring,
-                "☀️" => Season.Summer,
-                "🍂" => Season.Autumn,
-                "⛄" => Season.Winter,
-                _ => Enum.TryParse(name, out Season result) ? result : throw new JsonException()
+                "🌱" => 1,
+                "☀️" => 2,
+                "🍂" => 3,
+                "⛄" => 4,
+                _ => Enum.TryParse(name, out Season result) ? (int)result : throw new JsonException()
             };
         }
 
-        private Season ReadFromNumber(ref Utf8JsonReader reader)
+        private int ReadFromNumber(ref Utf8JsonReader reader)
         {
             return reader.TryGetInt32(out int value)
-                ? (Season)value
+                ? value
                 : throw new JsonException();
         }
     }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesExtensions.g.cs
@@ -15,14 +15,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this SlimCategories value)
         {
-            return value switch
+            return (byte)value switch
             {
-                SlimCategories.Electronics => nameof(SlimCategories.Electronics),
-                SlimCategories.Food => nameof(SlimCategories.Food),
-                SlimCategories.Automotive => nameof(SlimCategories.Automotive),
-                SlimCategories.Arts => nameof(SlimCategories.Arts),
-                SlimCategories.BeautyCare => nameof(SlimCategories.BeautyCare),
-                SlimCategories.Fashion => nameof(SlimCategories.Fashion),
+                0 => "Electronics",
+                1 => "Food",
+                2 => "Automotive",
+                3 => "Arts",
+                4 => "BeautyCare",
+                5 => "Fashion",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
@@ -31,32 +31,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out SlimCategories result)
         {
+            byte numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(SlimCategories.Electronics), comparisonType):
-                    result = SlimCategories.Electronics;
-                    return true;
-                case { } s when s.Equals(nameof(SlimCategories.Food), comparisonType):
-                    result = SlimCategories.Food;
-                    return true;
-                case { } s when s.Equals(nameof(SlimCategories.Automotive), comparisonType):
-                    result = SlimCategories.Automotive;
-                    return true;
-                case { } s when s.Equals(nameof(SlimCategories.Arts), comparisonType):
-                    result = SlimCategories.Arts;
-                    return true;
-                case { } s when s.Equals(nameof(SlimCategories.BeautyCare), comparisonType):
-                    result = SlimCategories.BeautyCare;
-                    return true;
-                case { } s when s.Equals(nameof(SlimCategories.Fashion), comparisonType):
-                    result = SlimCategories.Fashion;
-                    return true;
+                case { } s when s.Equals("Electronics", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Food", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Automotive", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Arts", comparisonType):
+                    numValue = 3;
+                    break;
+                case { } s when s.Equals("BeautyCare", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Fashion", comparisonType):
+                    numValue = 5;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out byte val):
-                    result = (SlimCategories)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (SlimCategories)numValue;
+            return true;
         }
 
         /// <summary>
@@ -74,32 +78,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out SlimCategories result)
         {
+            byte numValue;
             switch (name)
             {
-                case nameof(SlimCategories.Electronics):
-                    result = SlimCategories.Electronics;
-                    return true;
-                case nameof(SlimCategories.Food):
-                    result = SlimCategories.Food;
-                    return true;
-                case nameof(SlimCategories.Automotive):
-                    result = SlimCategories.Automotive;
-                    return true;
-                case nameof(SlimCategories.Arts):
-                    result = SlimCategories.Arts;
-                    return true;
-                case nameof(SlimCategories.BeautyCare):
-                    result = SlimCategories.BeautyCare;
-                    return true;
-                case nameof(SlimCategories.Fashion):
-                    result = SlimCategories.Fashion;
-                    return true;
+                case "Electronics":
+                    numValue = 0;
+                    break;
+                case "Food":
+                    numValue = 1;
+                    break;
+                case "Automotive":
+                    numValue = 2;
+                    break;
+                case "Arts":
+                    numValue = 3;
+                    break;
+                case "BeautyCare":
+                    numValue = 4;
+                    break;
+                case "Fashion":
+                    numValue = 5;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out byte val):
-                    result = (SlimCategories)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (SlimCategories)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,12 +178,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                SlimCategories.Electronics,
-                SlimCategories.Food,
-                SlimCategories.Automotive,
-                SlimCategories.Arts,
-                SlimCategories.BeautyCare,
-                SlimCategories.Fashion,
+                (SlimCategories)0,
+                (SlimCategories)1,
+                (SlimCategories)2,
+                (SlimCategories)3,
+                (SlimCategories)4,
+                (SlimCategories)5,
             };
         }
 
@@ -185,12 +193,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(SlimCategories.Electronics),
-                nameof(SlimCategories.Food),
-                nameof(SlimCategories.Automotive),
-                nameof(SlimCategories.Arts),
-                nameof(SlimCategories.BeautyCare),
-                nameof(SlimCategories.Fashion),
+                "Electronics",
+                "Food",
+                "Automotive",
+                "Arts",
+                "BeautyCare",
+                "Fashion",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
@@ -52,8 +52,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Fashion", comparisonType):
                     numValue = 5;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out byte val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -99,8 +98,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Fashion":
                     numValue = 5;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out byte val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesValidation.g.cs
@@ -16,14 +16,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="SlimCategories"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(SlimCategories value)
         {
-            return value switch
+            return (byte)value switch
             {
-                SlimCategories.Electronics => true,
-                SlimCategories.Food => true,
-                SlimCategories.Automotive => true,
-                SlimCategories.Arts => true,
-                SlimCategories.BeautyCare => true,
-                SlimCategories.Fashion => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+                5 => true,
                 _ => false
             };
         }
@@ -34,12 +34,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(SlimCategories.Electronics), comparisonType) => true,
-                { } s when s.Equals(nameof(SlimCategories.Food), comparisonType) => true,
-                { } s when s.Equals(nameof(SlimCategories.Automotive), comparisonType) => true,
-                { } s when s.Equals(nameof(SlimCategories.Arts), comparisonType) => true,
-                { } s when s.Equals(nameof(SlimCategories.BeautyCare), comparisonType) => true,
-                { } s when s.Equals(nameof(SlimCategories.Fashion), comparisonType) => true,
+                { } s when s.Equals("Electronics", comparisonType) => true,
+                { } s when s.Equals("Food", comparisonType) => true,
+                { } s when s.Equals("Automotive", comparisonType) => true,
+                { } s when s.Equals("Arts", comparisonType) => true,
+                { } s when s.Equals("BeautyCare", comparisonType) => true,
+                { } s when s.Equals("Fashion", comparisonType) => true,
                 _ => false
             };
         }
@@ -53,12 +53,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(SlimCategories.Electronics) => true,
-                nameof(SlimCategories.Food) => true,
-                nameof(SlimCategories.Automotive) => true,
-                nameof(SlimCategories.Arts) => true,
-                nameof(SlimCategories.BeautyCare) => true,
-                nameof(SlimCategories.Fashion) => true,
+                "Electronics" => true,
+                "Food" => true,
+                "Automotive" => true,
+                "Arts" => true,
+                "BeautyCare" => true,
+                "Fashion" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleExtensions.g.cs
@@ -17,14 +17,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this UserRole value)
         {
-            return value switch
+            return (ulong)value switch
             {
-                UserRole.None => nameof(UserRole.None),
-                UserRole.NormalUser => nameof(UserRole.NormalUser),
-                UserRole.Custodian => nameof(UserRole.Custodian),
-                UserRole.Finance => nameof(UserRole.Finance),
-                UserRole.SuperUser => nameof(UserRole.SuperUser),
-                UserRole.All => nameof(UserRole.All),
+                0 => "None",
+                1 => "NormalUser",
+                2 => "Custodian",
+                4 => "Finance",
+                6 => "SuperUser",
+                7 => "All",
                 _ => value.ToString()
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
@@ -52,8 +52,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("All", comparisonType):
                     numValue = 7;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out ulong val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -99,8 +98,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "All":
                     numValue = 7;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out ulong val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
@@ -31,32 +31,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out UserRole result)
         {
+            ulong numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(UserRole.None), comparisonType):
-                    result = UserRole.None;
-                    return true;
-                case { } s when s.Equals(nameof(UserRole.NormalUser), comparisonType):
-                    result = UserRole.NormalUser;
-                    return true;
-                case { } s when s.Equals(nameof(UserRole.Custodian), comparisonType):
-                    result = UserRole.Custodian;
-                    return true;
-                case { } s when s.Equals(nameof(UserRole.Finance), comparisonType):
-                    result = UserRole.Finance;
-                    return true;
-                case { } s when s.Equals(nameof(UserRole.SuperUser), comparisonType):
-                    result = UserRole.SuperUser;
-                    return true;
-                case { } s when s.Equals(nameof(UserRole.All), comparisonType):
-                    result = UserRole.All;
-                    return true;
+                case { } s when s.Equals("None", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("NormalUser", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Custodian", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Finance", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("SuperUser", comparisonType):
+                    numValue = 6;
+                    break;
+                case { } s when s.Equals("All", comparisonType):
+                    numValue = 7;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out ulong val):
-                    result = (UserRole)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (UserRole)numValue;
+            return true;
         }
 
         /// <summary>
@@ -74,32 +78,36 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out UserRole result)
         {
+            ulong numValue;
             switch (name)
             {
-                case nameof(UserRole.None):
-                    result = UserRole.None;
-                    return true;
-                case nameof(UserRole.NormalUser):
-                    result = UserRole.NormalUser;
-                    return true;
-                case nameof(UserRole.Custodian):
-                    result = UserRole.Custodian;
-                    return true;
-                case nameof(UserRole.Finance):
-                    result = UserRole.Finance;
-                    return true;
-                case nameof(UserRole.SuperUser):
-                    result = UserRole.SuperUser;
-                    return true;
-                case nameof(UserRole.All):
-                    result = UserRole.All;
-                    return true;
+                case "None":
+                    numValue = 0;
+                    break;
+                case "NormalUser":
+                    numValue = 1;
+                    break;
+                case "Custodian":
+                    numValue = 2;
+                    break;
+                case "Finance":
+                    numValue = 4;
+                    break;
+                case "SuperUser":
+                    numValue = 6;
+                    break;
+                case "All":
+                    numValue = 7;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out ulong val):
-                    result = (UserRole)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (UserRole)numValue;
+            return true;
         }
 
         /// <summary>
@@ -170,12 +178,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                UserRole.None,
-                UserRole.NormalUser,
-                UserRole.Custodian,
-                UserRole.Finance,
-                UserRole.SuperUser,
-                UserRole.All,
+                (UserRole)0,
+                (UserRole)1,
+                (UserRole)2,
+                (UserRole)4,
+                (UserRole)6,
+                (UserRole)7,
             };
         }
 
@@ -185,12 +193,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(UserRole.None),
-                nameof(UserRole.NormalUser),
-                nameof(UserRole.Custodian),
-                nameof(UserRole.Finance),
-                nameof(UserRole.SuperUser),
-                nameof(UserRole.All),
+                "None",
+                "NormalUser",
+                "Custodian",
+                "Finance",
+                "SuperUser",
+                "All",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleValidation.g.cs
@@ -16,14 +16,14 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="UserRole"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(UserRole value)
         {
-            return value switch
+            return (ulong)value switch
             {
-                UserRole.None => true,
-                UserRole.NormalUser => true,
-                UserRole.Custodian => true,
-                UserRole.Finance => true,
-                UserRole.SuperUser => true,
-                UserRole.All => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                4 => true,
+                6 => true,
+                7 => true,
                 _ => false
             };
         }
@@ -34,12 +34,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(UserRole.None), comparisonType) => true,
-                { } s when s.Equals(nameof(UserRole.NormalUser), comparisonType) => true,
-                { } s when s.Equals(nameof(UserRole.Custodian), comparisonType) => true,
-                { } s when s.Equals(nameof(UserRole.Finance), comparisonType) => true,
-                { } s when s.Equals(nameof(UserRole.SuperUser), comparisonType) => true,
-                { } s when s.Equals(nameof(UserRole.All), comparisonType) => true,
+                { } s when s.Equals("None", comparisonType) => true,
+                { } s when s.Equals("NormalUser", comparisonType) => true,
+                { } s when s.Equals("Custodian", comparisonType) => true,
+                { } s when s.Equals("Finance", comparisonType) => true,
+                { } s when s.Equals("SuperUser", comparisonType) => true,
+                { } s when s.Equals("All", comparisonType) => true,
                 _ => false
             };
         }
@@ -53,12 +53,12 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(UserRole.None) => true,
-                nameof(UserRole.NormalUser) => true,
-                nameof(UserRole.Custodian) => true,
-                nameof(UserRole.Finance) => true,
-                nameof(UserRole.SuperUser) => true,
-                nameof(UserRole.All) => true,
+                "None" => true,
+                "NormalUser" => true,
+                "Custodian" => true,
+                "Finance" => true,
+                "SuperUser" => true,
+                "All" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysExtensions.g.cs
@@ -17,15 +17,15 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns>The string representation of the value of this instance.</returns>
         public static string ToStringFast(this WeekDays value)
         {
-            return value switch
+            return (int)value switch
             {
-                WeekDays.Monday => nameof(WeekDays.Monday),
-                WeekDays.Tuesday => nameof(WeekDays.Tuesday),
-                WeekDays.Wednesday => nameof(WeekDays.Wednesday),
-                WeekDays.Thursday => nameof(WeekDays.Thursday),
-                WeekDays.Friday => nameof(WeekDays.Friday),
-                WeekDays.Saturday => nameof(WeekDays.Saturday),
-                WeekDays.Sunday => nameof(WeekDays.Sunday),
+                0 => "Monday",
+                1 => "Tuesday",
+                2 => "Wednesday",
+                3 => "Thursday",
+                4 => "Friday",
+                5 => "Saturday",
+                6 => "Sunday",
                 _ => value.ToString()
             };
         }
@@ -93,38 +93,38 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         public static string GetDisplayShortName(this WeekDays value)
         {
-            return value switch
+            return (int)value switch
             {
-                WeekDays.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort,
-                WeekDays.Tuesday => "Tue",
-                WeekDays.Friday => "Fri",
-                WeekDays.Saturday => "Sat",
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort,
+                1 => "Tue",
+                4 => "Fri",
+                5 => "Sat",
                 _ => GetDisplayName(value)
             };
         }
 
         public static string GetDisplayName(this WeekDays value)
         {
-            return value switch
+            return (int)value switch
             {
-                WeekDays.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull,
-                WeekDays.Tuesday => nameof(WeekDays.Tuesday),
-                WeekDays.Wednesday => nameof(WeekDays.Wednesday),
-                WeekDays.Thursday => "Thursday",
-                WeekDays.Friday => "Friday",
-                WeekDays.Saturday => nameof(WeekDays.Saturday),
-                WeekDays.Sunday => nameof(WeekDays.Sunday),
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull,
+                1 => "Tuesday",
+                2 => "Wednesday",
+                3 => "Thursday",
+                4 => "Friday",
+                5 => "Saturday",
+                6 => "Sunday",
                 _ => value.ToString()
             };
         }
 
         public static string? GetDescription(this WeekDays value)
         {
-            return value switch
+            return (int)value switch
             {
-                WeekDays.Monday => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription,
-                WeekDays.Saturday => "Almost the last day of the week",
-                WeekDays.Sunday => "The last day of the week",
+                0 => Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription,
+                5 => "Almost the last day of the week",
+                6 => "The last day of the week",
                 _ => null
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
@@ -55,8 +55,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case { } s when s.Equals("Sunday", comparisonType):
                     numValue = 6;
                     break;
-                case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, comparisonType, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);
@@ -105,8 +104,7 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 case "Sunday":
                     numValue = 6;
                     break;
-                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    numValue = val;
+                case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                     break;
                 default:
                     return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
@@ -31,35 +31,39 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out WeekDays result)
         {
+            int numValue;
             switch (name)
             {
-                case { } s when s.Equals(nameof(WeekDays.Monday), comparisonType):
-                    result = WeekDays.Monday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Tuesday), comparisonType):
-                    result = WeekDays.Tuesday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Wednesday), comparisonType):
-                    result = WeekDays.Wednesday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Thursday), comparisonType):
-                    result = WeekDays.Thursday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Friday), comparisonType):
-                    result = WeekDays.Friday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Saturday), comparisonType):
-                    result = WeekDays.Saturday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Sunday), comparisonType):
-                    result = WeekDays.Sunday;
-                    return true;
+                case { } s when s.Equals("Monday", comparisonType):
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Tuesday", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Wednesday", comparisonType):
+                    numValue = 2;
+                    break;
+                case { } s when s.Equals("Thursday", comparisonType):
+                    numValue = 3;
+                    break;
+                case { } s when s.Equals("Friday", comparisonType):
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Saturday", comparisonType):
+                    numValue = 5;
+                    break;
+                case { } s when s.Equals("Sunday", comparisonType):
+                    numValue = 6;
+                    break;
                 case { } s when TryParseNumeric(s, comparisonType, out int val):
-                    result = (WeekDays)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (WeekDays)numValue;
+            return true;
         }
 
         /// <summary>
@@ -77,35 +81,39 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             [NotNullWhen(true)] string? name,
             out WeekDays result)
         {
+            int numValue;
             switch (name)
             {
-                case nameof(WeekDays.Monday):
-                    result = WeekDays.Monday;
-                    return true;
-                case nameof(WeekDays.Tuesday):
-                    result = WeekDays.Tuesday;
-                    return true;
-                case nameof(WeekDays.Wednesday):
-                    result = WeekDays.Wednesday;
-                    return true;
-                case nameof(WeekDays.Thursday):
-                    result = WeekDays.Thursday;
-                    return true;
-                case nameof(WeekDays.Friday):
-                    result = WeekDays.Friday;
-                    return true;
-                case nameof(WeekDays.Saturday):
-                    result = WeekDays.Saturday;
-                    return true;
-                case nameof(WeekDays.Sunday):
-                    result = WeekDays.Sunday;
-                    return true;
+                case "Monday":
+                    numValue = 0;
+                    break;
+                case "Tuesday":
+                    numValue = 1;
+                    break;
+                case "Wednesday":
+                    numValue = 2;
+                    break;
+                case "Thursday":
+                    numValue = 3;
+                    break;
+                case "Friday":
+                    numValue = 4;
+                    break;
+                case "Saturday":
+                    numValue = 5;
+                    break;
+                case "Sunday":
+                    numValue = 6;
+                    break;
                 case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                    result = (WeekDays)val;
-                    return true;
+                    numValue = val;
+                    break;
                 default:
                     return Enum.TryParse(name, out result);
             }
+
+            result = (WeekDays)numValue;
+            return true;
         }
 
         /// <summary>
@@ -175,23 +183,27 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out WeekDays result)
         {
+            int numValue;
             switch (displayShortName)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayShort, comparisonType):
-                    result = WeekDays.Monday;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Tue", comparisonType):
-                    result = WeekDays.Tuesday;
-                    return true;
+                    numValue = 1;
+                    break;
                 case { } s when s.Equals("Fri", comparisonType):
-                    result = WeekDays.Friday;
-                    return true;
+                    numValue = 4;
+                    break;
                 case { } s when s.Equals("Sat", comparisonType):
-                    result = WeekDays.Saturday;
-                    return true;
+                    numValue = 5;
+                    break;
                 default:
                     return TryCreateFromDisplayName(displayShortName, comparisonType, out result);
             }
+
+            result = (WeekDays)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayShortName([NotNullWhen(true)] string? displayShortName, out WeekDays result)
@@ -214,33 +226,37 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out WeekDays result)
         {
+            int numValue;
             switch (displayName)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayFull, comparisonType):
-                    result = WeekDays.Monday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Tuesday), comparisonType):
-                    result = WeekDays.Tuesday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Wednesday), comparisonType):
-                    result = WeekDays.Wednesday;
-                    return true;
+                    numValue = 0;
+                    break;
+                case { } s when s.Equals("Tuesday", comparisonType):
+                    numValue = 1;
+                    break;
+                case { } s when s.Equals("Wednesday", comparisonType):
+                    numValue = 2;
+                    break;
                 case { } s when s.Equals("Thursday", comparisonType):
-                    result = WeekDays.Thursday;
-                    return true;
+                    numValue = 3;
+                    break;
                 case { } s when s.Equals("Friday", comparisonType):
-                    result = WeekDays.Friday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Saturday), comparisonType):
-                    result = WeekDays.Saturday;
-                    return true;
-                case { } s when s.Equals(nameof(WeekDays.Sunday), comparisonType):
-                    result = WeekDays.Sunday;
-                    return true;
+                    numValue = 4;
+                    break;
+                case { } s when s.Equals("Saturday", comparisonType):
+                    numValue = 5;
+                    break;
+                case { } s when s.Equals("Sunday", comparisonType):
+                    numValue = 6;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (WeekDays)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDisplayName([NotNullWhen(true)] string? displayName, out WeekDays result)
@@ -263,21 +279,25 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             StringComparison comparisonType,
             out WeekDays result)
         {
+            int numValue;
             switch (description)
             {
                 case { } s when s.Equals(Raiqub.Generators.EnumUtilities.IntegrationTests.Strings.MondayDescription, comparisonType):
-                    result = WeekDays.Monday;
-                    return true;
+                    numValue = 0;
+                    break;
                 case { } s when s.Equals("Almost the last day of the week", comparisonType):
-                    result = WeekDays.Saturday;
-                    return true;
+                    numValue = 5;
+                    break;
                 case { } s when s.Equals("The last day of the week", comparisonType):
-                    result = WeekDays.Sunday;
-                    return true;
+                    numValue = 6;
+                    break;
                 default:
                     result = default;
                     return false;
             }
+
+            result = (WeekDays)numValue;
+            return true;
         }
 
         public static bool TryCreateFromDescription([NotNullWhen(true)] string? description, out WeekDays result)
@@ -301,13 +321,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                WeekDays.Monday,
-                WeekDays.Tuesday,
-                WeekDays.Wednesday,
-                WeekDays.Thursday,
-                WeekDays.Friday,
-                WeekDays.Saturday,
-                WeekDays.Sunday,
+                (WeekDays)0,
+                (WeekDays)1,
+                (WeekDays)2,
+                (WeekDays)3,
+                (WeekDays)4,
+                (WeekDays)5,
+                (WeekDays)6,
             };
         }
 
@@ -317,13 +337,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return new[]
             {
-                nameof(WeekDays.Monday),
-                nameof(WeekDays.Tuesday),
-                nameof(WeekDays.Wednesday),
-                nameof(WeekDays.Thursday),
-                nameof(WeekDays.Friday),
-                nameof(WeekDays.Saturday),
-                nameof(WeekDays.Sunday),
+                "Monday",
+                "Tuesday",
+                "Wednesday",
+                "Thursday",
+                "Friday",
+                "Saturday",
+                "Sunday",
             };
         }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysValidation.g.cs
@@ -16,15 +16,15 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         /// <returns><c>true</c> if the value of <see cref="WeekDays"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
         public static bool IsDefined(WeekDays value)
         {
-            return value switch
+            return (int)value switch
             {
-                WeekDays.Monday => true,
-                WeekDays.Tuesday => true,
-                WeekDays.Wednesday => true,
-                WeekDays.Thursday => true,
-                WeekDays.Friday => true,
-                WeekDays.Saturday => true,
-                WeekDays.Sunday => true,
+                0 => true,
+                1 => true,
+                2 => true,
+                3 => true,
+                4 => true,
+                5 => true,
+                6 => true,
                 _ => false
             };
         }
@@ -35,13 +35,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                { } s when s.Equals(nameof(WeekDays.Monday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Tuesday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Wednesday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Thursday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Friday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Saturday), comparisonType) => true,
-                { } s when s.Equals(nameof(WeekDays.Sunday), comparisonType) => true,
+                { } s when s.Equals("Monday", comparisonType) => true,
+                { } s when s.Equals("Tuesday", comparisonType) => true,
+                { } s when s.Equals("Wednesday", comparisonType) => true,
+                { } s when s.Equals("Thursday", comparisonType) => true,
+                { } s when s.Equals("Friday", comparisonType) => true,
+                { } s when s.Equals("Saturday", comparisonType) => true,
+                { } s when s.Equals("Sunday", comparisonType) => true,
                 _ => false
             };
         }
@@ -55,13 +55,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
         {
             return name switch
             {
-                nameof(WeekDays.Monday) => true,
-                nameof(WeekDays.Tuesday) => true,
-                nameof(WeekDays.Wednesday) => true,
-                nameof(WeekDays.Thursday) => true,
-                nameof(WeekDays.Friday) => true,
-                nameof(WeekDays.Saturday) => true,
-                nameof(WeekDays.Sunday) => true,
+                "Monday" => true,
+                "Tuesday" => true,
+                "Wednesday" => true,
+                "Thursday" => true,
+                "Friday" => true,
+                "Saturday" => true,
+                "Sunday" => true,
                 _ => false
             };
         }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceExtensions.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceExtensions.g.cs
@@ -15,11 +15,11 @@ public static partial class NoNamespaceExtensions
     /// <returns>The string representation of the value of this instance.</returns>
     public static string ToStringFast(this NoNamespace value)
     {
-        return value switch
+        return (int)value switch
         {
-            NoNamespace.Zero => nameof(NoNamespace.Zero),
-            NoNamespace.One => nameof(NoNamespace.One),
-            NoNamespace.Two => nameof(NoNamespace.Two),
+            0 => "Zero",
+            1 => "One",
+            2 => "Two",
             _ => value.ToString()
         };
     }

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
@@ -41,8 +41,7 @@ public static partial class NoNamespaceFactory
             case { } s when s.Equals("Two", comparisonType):
                 numValue = 2;
                 break;
-            case { } s when TryParseNumeric(s, comparisonType, out int val):
-                numValue = val;
+            case { } s when TryParseNumeric(s, comparisonType, out numValue):
                 break;
             default:
                 return Enum.TryParse(name, out result);
@@ -79,8 +78,7 @@ public static partial class NoNamespaceFactory
             case "Two":
                 numValue = 2;
                 break;
-            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                numValue = val;
+            case { } s when TryParseNumeric(s, StringComparison.Ordinal, out numValue):
                 break;
             default:
                 return Enum.TryParse(name, out result);

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
@@ -29,23 +29,27 @@ public static partial class NoNamespaceFactory
         StringComparison comparisonType,
         out NoNamespace result)
     {
+        int numValue;
         switch (name)
         {
-            case { } s when s.Equals(nameof(NoNamespace.Zero), comparisonType):
-                result = NoNamespace.Zero;
-                return true;
-            case { } s when s.Equals(nameof(NoNamespace.One), comparisonType):
-                result = NoNamespace.One;
-                return true;
-            case { } s when s.Equals(nameof(NoNamespace.Two), comparisonType):
-                result = NoNamespace.Two;
-                return true;
+            case { } s when s.Equals("Zero", comparisonType):
+                numValue = 0;
+                break;
+            case { } s when s.Equals("One", comparisonType):
+                numValue = 1;
+                break;
+            case { } s when s.Equals("Two", comparisonType):
+                numValue = 2;
+                break;
             case { } s when TryParseNumeric(s, comparisonType, out int val):
-                result = (NoNamespace)val;
-                return true;
+                numValue = val;
+                break;
             default:
                 return Enum.TryParse(name, out result);
         }
+
+        result = (NoNamespace)numValue;
+        return true;
     }
 
     /// <summary>
@@ -63,23 +67,27 @@ public static partial class NoNamespaceFactory
         [NotNullWhen(true)] string? name,
         out NoNamespace result)
     {
+        int numValue;
         switch (name)
         {
-            case nameof(NoNamespace.Zero):
-                result = NoNamespace.Zero;
-                return true;
-            case nameof(NoNamespace.One):
-                result = NoNamespace.One;
-                return true;
-            case nameof(NoNamespace.Two):
-                result = NoNamespace.Two;
-                return true;
+            case "Zero":
+                numValue = 0;
+                break;
+            case "One":
+                numValue = 1;
+                break;
+            case "Two":
+                numValue = 2;
+                break;
             case { } s when TryParseNumeric(s, StringComparison.Ordinal, out int val):
-                result = (NoNamespace)val;
-                return true;
+                numValue = val;
+                break;
             default:
                 return Enum.TryParse(name, out result);
         }
+
+        result = (NoNamespace)numValue;
+        return true;
     }
 
     /// <summary>
@@ -150,9 +158,9 @@ public static partial class NoNamespaceFactory
     {
         return new[]
         {
-            NoNamespace.Zero,
-            NoNamespace.One,
-            NoNamespace.Two,
+            (NoNamespace)0,
+            (NoNamespace)1,
+            (NoNamespace)2,
         };
     }
 
@@ -162,9 +170,9 @@ public static partial class NoNamespaceFactory
     {
         return new[]
         {
-            nameof(NoNamespace.Zero),
-            nameof(NoNamespace.One),
-            nameof(NoNamespace.Two),
+            "Zero",
+            "One",
+            "Two",
         };
     }
 

--- a/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceValidation.g.cs
+++ b/tests/EnumUtilities.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceValidation.g.cs
@@ -14,11 +14,11 @@ public static partial class NoNamespaceValidation
     /// <returns><c>true</c> if the value of <see cref="NoNamespace"/> instance exists in the enumeration; <c>false</c> otherwise.</returns>
     public static bool IsDefined(NoNamespace value)
     {
-        return value switch
+        return (int)value switch
         {
-            NoNamespace.Zero => true,
-            NoNamespace.One => true,
-            NoNamespace.Two => true,
+            0 => true,
+            1 => true,
+            2 => true,
             _ => false
         };
     }
@@ -29,9 +29,9 @@ public static partial class NoNamespaceValidation
     {
         return name switch
         {
-            { } s when s.Equals(nameof(NoNamespace.Zero), comparisonType) => true,
-            { } s when s.Equals(nameof(NoNamespace.One), comparisonType) => true,
-            { } s when s.Equals(nameof(NoNamespace.Two), comparisonType) => true,
+            { } s when s.Equals("Zero", comparisonType) => true,
+            { } s when s.Equals("One", comparisonType) => true,
+            { } s when s.Equals("Two", comparisonType) => true,
             _ => false
         };
     }
@@ -45,9 +45,9 @@ public static partial class NoNamespaceValidation
     {
         return name switch
         {
-            nameof(NoNamespace.Zero) => true,
-            nameof(NoNamespace.One) => true,
-            nameof(NoNamespace.Two) => true,
+            "Zero" => true,
+            "One" => true,
+            "Two" => true,
             _ => false
         };
     }

--- a/tests/EnumUtilities.IntegrationTests/Models/BigErrorCode.cs
+++ b/tests/EnumUtilities.IntegrationTests/Models/BigErrorCode.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models;
+
+[JsonConverterGenerator(DeserializationFailureFallbackValue = 0, AllowIntegerValues = false)]
+[JsonConverter(typeof(ErrorCodeJsonConverter))]
+internal enum BigErrorCode : ulong
+{
+    [JsonPropertyName("NON")]
+    None = 0,
+
+    [JsonPropertyName("UNK")]
+    Unknown = 1,
+
+    [JsonPropertyName("CNX")]
+    ConnectionLost = 100,
+
+    [JsonPropertyName("OUT")]
+    OutlierReading = 200_000_000_000
+}

--- a/tests/EnumUtilities.IntegrationTests/Models/EmptyEnum.cs
+++ b/tests/EnumUtilities.IntegrationTests/Models/EmptyEnum.cs
@@ -1,0 +1,6 @@
+﻿namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models;
+
+#pragma warning disable CA1711
+
+[EnumGenerator]
+public enum EmptyEnum;

--- a/tests/EnumUtilities.IntegrationTests/Models/EmptyEnum.cs
+++ b/tests/EnumUtilities.IntegrationTests/Models/EmptyEnum.cs
@@ -3,4 +3,5 @@
 #pragma warning disable CA1711
 
 [EnumGenerator]
+[JsonConverterGenerator]
 public enum EmptyEnum;

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.6",
+    "version": "1.7",
     "publicReleaseRefSpec": [
         "^refs/tags/v\\d+\\.\\d+"
     ],


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub EnumUtilities!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- The generated code creates too many references to the enum itself and its members making the usage tracking difficult
- Unused enum members are not tracked by analyzers because of generated code references

## Details on the issue fix or feature implementation
- Reduce references to enum to a minimum
- Remove all references to enum members (use numbers)

## Confirm the following
- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
