### PR TITLE
fix: Resolve incompatibility issues with .NET 6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://github.com/skarllot/EnumUtilities#guide
     about: Read our documentation.
   - name: ⭐ Sponsor Raiqub Enum Utilities
-    url: https://www.buymeacoffee.com/skarllot
+    url: https://github.com/sponsors/skarllot
     about: Help the continued development.
   - name: 💬 Ask on Github Discussions
     url: https://github.com/skarllot/EnumUtilities/discussions

--- a/gen/EnumUtilities.Generators/CodeWriters/EnumFactoryWriter.cs
+++ b/gen/EnumUtilities.Generators/CodeWriters/EnumFactoryWriter.cs
@@ -747,7 +747,7 @@ this.Write(" result)\r\n        {\r\n            switch (value)\r\n            {
         #line hidden
         
         #line 188 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("                case \"");
+this.Write("                case { } when value.SequenceEqual(\"");
 
         
         #line default
@@ -761,7 +761,7 @@ this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberName));
         #line hidden
         
         #line 188 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\Factory\DefaultBlock.ttinclude"
-this.Write("\":\r\n                    result = ");
+this.Write("\".AsSpan()):\r\n                    result = ");
 
         
         #line default

--- a/gen/EnumUtilities.Generators/CodeWriters/EnumJsonConverterWriter.cs
+++ b/gen/EnumUtilities.Generators/CodeWriters/EnumJsonConverterWriter.cs
@@ -149,23 +149,23 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             
             #line default
             #line hidden
-            this.Write(";\r\n    }\r\n\r\n    public override void Write(Utf8JsonWriter writer, ");
+            this.Write(";\r\n    }\r\n\r\n#if NET7_0_OR_GREATER\r\n\r\n    public override void Write(Utf8JsonWriter writer, ");
             
-            #line 54 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
             
             #line default
             #line hidden
             this.Write(" value, JsonSerializerOptions options)\r\n    {\r\n        switch ((");
             
-            #line 56 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
             this.Write(")value)\r\n        {\r\n");
             
-            #line 58 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 60 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     foreach (var curr in Model.UniqueValues)
     {
@@ -175,21 +175,21 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("            case ");
             
-            #line 62 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 64 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
             
             #line default
             #line hidden
             this.Write(":\r\n                writer.WriteStringValue(\"");
             
-            #line 63 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.JsonPropertyName ?? curr.SerializationValue ?? curr.MemberName));
             
             #line default
             #line hidden
             this.Write("\"u8);\r\n                break;\r\n");
             
-            #line 65 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 67 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     }
 
@@ -198,21 +198,21 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("            default:\r\n                writer.WriteStringValue(value.ToString());\r\n                break;\r\n        }\r\n    }\r\n\r\n    private ");
             
-            #line 74 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 76 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
-            this.Write(" ReadFromString(ref Utf8JsonReader reader)\r\n    {\r\n#if NET7_0_OR_GREATER\r\n        int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;\r\n        if (length > MaxBytesLength)\r\n            ");
+            this.Write(" ReadFromString(ref Utf8JsonReader reader)\r\n    {\r\n        int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;\r\n        if (length > MaxBytesLength)\r\n            ");
             
-            #line 79 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 80 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue(addReturn: true)));
             
             #line default
             #line hidden
-            this.Write(";\r\n\r\n        Span<char> name = stackalloc char[MaxBytesLength];\r\n        int charsWritten = reader.CopyString(name);\r\n        name = name.Slice(0, charsWritten);\r\n#else\r\n        string? name = reader.GetString();\r\n#endif\r\n\r\n        return name switch\r\n        {\r\n");
+            this.Write(";\r\n\r\n        Span<char> name = stackalloc char[MaxBytesLength];\r\n        int charsWritten = reader.CopyString(name);\r\n        name = name.Slice(0, charsWritten);\r\n\r\n        return name switch\r\n        {\r\n");
             
-            #line 90 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 88 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     foreach (var curr in Model.Values)
     {
@@ -222,7 +222,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("            ");
             
-            #line 94 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 92 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.JsonPropertyName is not null || curr.SerializationValue is not null
                     ? Append($"\"{curr.JsonPropertyName ?? curr.SerializationValue}\"")
                     : Append($"\"{curr.MemberName}\"")));
@@ -231,20 +231,20 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write(" => ");
             
-            #line 97 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 95 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(NeedNumberCasting() ? Append($"({Model.UnderlyingType})") : Append("")));
             
             #line default
             #line hidden
             
-            #line 97 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 95 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
             
             #line default
             #line hidden
             this.Write(",\r\n");
             
-            #line 98 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 96 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     }
 
@@ -253,28 +253,144 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("            _ => Enum.TryParse(name, out ");
             
-            #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 99 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
             
             #line default
             #line hidden
             this.Write(" result) ? (");
             
-            #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 99 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
             this.Write(")result : ");
             
-            #line 101 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 99 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue()));
             
             #line default
             #line hidden
-            this.Write("\r\n        };\r\n    }\r\n");
+            this.Write("\r\n        };\r\n    }\r\n\r\n#else\r\n\r\n    public override void Write(Utf8JsonWriter writer, ");
             
-            #line 104 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 105 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.Name));
+            
+            #line default
+            #line hidden
+            this.Write(" value, JsonSerializerOptions options)\r\n    {\r\n        switch ((");
+            
+            #line 107 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(")value)\r\n        {\r\n");
+            
+            #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+
+    foreach (var curr in Model.UniqueValues)
+    {
+
+            
+            #line default
+            #line hidden
+            this.Write("            case ");
+            
+            #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+            
+            #line default
+            #line hidden
+            this.Write(":\r\n                writer.WriteStringValue(\"");
+            
+            #line 114 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.JsonPropertyName ?? curr.SerializationValue ?? curr.MemberName));
+            
+            #line default
+            #line hidden
+            this.Write("\");\r\n                break;\r\n");
+            
+            #line 116 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+
+    }
+
+            
+            #line default
+            #line hidden
+            this.Write("            default:\r\n                writer.WriteStringValue(value.ToString());\r\n                break;\r\n        }\r\n    }\r\n\r\n    private ");
+            
+            #line 125 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(" ReadFromString(ref Utf8JsonReader reader)\r\n    {\r\n        var name = reader.GetString();\r\n        return name switch\r\n        {\r\n");
+            
+            #line 130 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+
+    foreach (var curr in Model.Values)
+    {
+
+            
+            #line default
+            #line hidden
+            this.Write("            ");
+            
+            #line 134 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.JsonPropertyName is not null || curr.SerializationValue is not null
+                    ? Append($"\"{curr.JsonPropertyName ?? curr.SerializationValue}\"")
+                    : Append($"\"{curr.MemberName}\"")));
+            
+            #line default
+            #line hidden
+            this.Write(" => ");
+            
+            #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(NeedNumberCasting() ? Append($"({Model.UnderlyingType})") : Append("")));
+            
+            #line default
+            #line hidden
+            
+            #line 137 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(curr.MemberValue));
+            
+            #line default
+            #line hidden
+            this.Write(",\r\n");
+            
+            #line 138 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+
+    }
+
+            
+            #line default
+            #line hidden
+            this.Write("            _ => Enum.TryParse(name, out ");
+            
+            #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.RefName));
+            
+            #line default
+            #line hidden
+            this.Write(" result) ? (");
+            
+            #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
+            
+            #line default
+            #line hidden
+            this.Write(")result : ");
+            
+            #line 141 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue()));
+            
+            #line default
+            #line hidden
+            this.Write("\r\n        };\r\n    }\r\n\r\n#endif\r\n");
+            
+            #line 146 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     if (Model.JsonConverterGeneratorOptions.AllowIntegerValues)
     {
@@ -284,35 +400,35 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("\r\n    private ");
             
-            #line 109 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 151 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
             this.Write(" ReadFromNumber(ref Utf8JsonReader reader)\r\n    {\r\n        return reader.TryGet");
             
-            #line 111 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(CSharpExtensions.GetTypeNameFromCSharpKeyword(Model.UnderlyingType)));
             
             #line default
             #line hidden
             this.Write("(out ");
             
-            #line 111 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 153 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.UnderlyingType));
             
             #line default
             #line hidden
             this.Write(" value)\r\n            ? value\r\n            : ");
             
-            #line 113 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 155 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture(AppendFallbackValue()));
             
             #line default
             #line hidden
             this.Write(";\r\n    }\r\n");
             
-            #line 115 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 157 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     }
 
@@ -321,7 +437,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             #line hidden
             this.Write("}\r\n");
             
-            #line 119 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+            #line 161 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
     if (!string.IsNullOrEmpty(Model.Namespace))
     {
@@ -335,7 +451,7 @@ namespace Raiqub.Generators.EnumUtilities.CodeWriters
             return this.GenerationEnvironment.ToString();
         }
         
-        #line 126 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
+        #line 168 "C:\Users\skarl\source\repos\github\skarllot\EnumUtilities\gen\EnumUtilities.Generators\CodeWriters\EnumJsonConverterWriter.tt"
 
 #nullable enable
     public EnumJsonConverterWriter(StringBuilder builder) : base(builder)

--- a/gen/EnumUtilities.Generators/CodeWriters/EnumJsonConverterWriter.tt
+++ b/gen/EnumUtilities.Generators/CodeWriters/EnumJsonConverterWriter.tt
@@ -51,6 +51,8 @@ using System.Text.Json.Serialization;
         <#= AppendFallbackValue(addReturn: true, castToEnum: true) #>;
     }
 
+#if NET7_0_OR_GREATER
+
     public override void Write(Utf8JsonWriter writer, <#= Model.Name #> value, JsonSerializerOptions options)
     {
         switch ((<#= Model.UnderlyingType #>)value)
@@ -73,7 +75,6 @@ using System.Text.Json.Serialization;
 
     private <#= Model.UnderlyingType #> ReadFromString(ref Utf8JsonReader reader)
     {
-#if NET7_0_OR_GREATER
         int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
         if (length > MaxBytesLength)
             <#= AppendFallbackValue(addReturn: true) #>;
@@ -81,9 +82,6 @@ using System.Text.Json.Serialization;
         Span<char> name = stackalloc char[MaxBytesLength];
         int charsWritten = reader.CopyString(name);
         name = name.Slice(0, charsWritten);
-#else
-        string? name = reader.GetString();
-#endif
 
         return name switch
         {
@@ -101,6 +99,50 @@ using System.Text.Json.Serialization;
             _ => Enum.TryParse(name, out <#= Model.RefName #> result) ? (<#= Model.UnderlyingType #>)result : <#= AppendFallbackValue() #>
         };
     }
+
+#else
+
+    public override void Write(Utf8JsonWriter writer, <#= Model.Name #> value, JsonSerializerOptions options)
+    {
+        switch ((<#= Model.UnderlyingType #>)value)
+        {
+<#
+    foreach (var curr in Model.UniqueValues)
+    {
+#>
+            case <#= curr.MemberValue #>:
+                writer.WriteStringValue("<#= curr.JsonPropertyName ?? curr.SerializationValue ?? curr.MemberName #>");
+                break;
+<#
+    }
+#>
+            default:
+                writer.WriteStringValue(value.ToString());
+                break;
+        }
+    }
+
+    private <#= Model.UnderlyingType #> ReadFromString(ref Utf8JsonReader reader)
+    {
+        var name = reader.GetString();
+        return name switch
+        {
+<#
+    foreach (var curr in Model.Values)
+    {
+#>
+            <#=
+                curr.JsonPropertyName is not null || curr.SerializationValue is not null
+                    ? Append($"\"{curr.JsonPropertyName ?? curr.SerializationValue}\"")
+                    : Append($"\"{curr.MemberName}\"") #> => <#= NeedNumberCasting() ? Append($"({Model.UnderlyingType})") : Append("") #><#= curr.MemberValue #>,
+<#
+    }
+#>
+            _ => Enum.TryParse(name, out <#= Model.RefName #> result) ? (<#= Model.UnderlyingType #>)result : <#= AppendFallbackValue() #>
+        };
+    }
+
+#endif
 <#
     if (Model.JsonConverterGeneratorOptions.AllowIntegerValues)
     {

--- a/gen/EnumUtilities.Generators/CodeWriters/Factory/DefaultBlock.ttinclude
+++ b/gen/EnumUtilities.Generators/CodeWriters/Factory/DefaultBlock.ttinclude
@@ -185,7 +185,7 @@
         foreach (var curr in Model.Values)
         {
 #>
-                case "<#= curr.MemberName #>":
+                case { } when value.SequenceEqual("<#= curr.MemberName #>".AsSpan()):
                     result = <#= curr.MemberValue #>;
                     return true;
 <#+

--- a/tests/EnumUtilities.Generators.IntegrationTests/EnumUtilities.Generators.IntegrationTests.csproj
+++ b/tests/EnumUtilities.Generators.IntegrationTests/EnumUtilities.Generators.IntegrationTests.csproj
@@ -7,6 +7,10 @@
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
     <Using Include="Xunit" />

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.BigErrorCodeJsonConverter.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.BigErrorCodeJsonConverter.g.cs
@@ -24,6 +24,8 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             return (BigErrorCode)0;
         }
 
+    #if NET7_0_OR_GREATER
+
         public override void Write(Utf8JsonWriter writer, BigErrorCode value, JsonSerializerOptions options)
         {
             switch ((ulong)value)
@@ -48,7 +50,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         private ulong ReadFromString(ref Utf8JsonReader reader)
         {
-    #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
             if (length > MaxBytesLength)
                 return 0;
@@ -56,9 +57,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             Span<char> name = stackalloc char[MaxBytesLength];
             int charsWritten = reader.CopyString(name);
             name = name.Slice(0, charsWritten);
-    #else
-            string? name = reader.GetString();
-    #endif
 
             return name switch
             {
@@ -69,5 +67,44 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 _ => Enum.TryParse(name, out BigErrorCode result) ? (ulong)result : 0
             };
         }
+
+    #else
+
+        public override void Write(Utf8JsonWriter writer, BigErrorCode value, JsonSerializerOptions options)
+        {
+            switch ((ulong)value)
+            {
+                case 0:
+                    writer.WriteStringValue("NON");
+                    break;
+                case 1:
+                    writer.WriteStringValue("UNK");
+                    break;
+                case 100:
+                    writer.WriteStringValue("CNX");
+                    break;
+                case 200000000000:
+                    writer.WriteStringValue("OUT");
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
+        }
+
+        private ulong ReadFromString(ref Utf8JsonReader reader)
+        {
+            var name = reader.GetString();
+            return name switch
+            {
+                "NON" => 0,
+                "UNK" => 1,
+                "CNX" => 100,
+                "OUT" => 200000000000,
+                _ => Enum.TryParse(name, out BigErrorCode result) ? (ulong)result : 0
+            };
+        }
+
+    #endif
     }
 }

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.CategoriesFactory.g.cs
@@ -194,22 +194,22 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Electronics":
+                    case { } when value.SequenceEqual("Electronics".AsSpan()):
                         result = 0;
                         return true;
-                    case "Food":
+                    case { } when value.SequenceEqual("Food".AsSpan()):
                         result = 1;
                         return true;
-                    case "Automotive":
+                    case { } when value.SequenceEqual("Automotive".AsSpan()):
                         result = 2;
                         return true;
-                    case "Arts":
+                    case { } when value.SequenceEqual("Arts".AsSpan()):
                         result = 3;
                         return true;
-                    case "BeautyCare":
+                    case { } when value.SequenceEqual("BeautyCare".AsSpan()):
                         result = 4;
                         return true;
-                    case "Fashion":
+                    case { } when value.SequenceEqual("Fashion".AsSpan()):
                         result = 5;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ColoursFactory.g.cs
@@ -194,13 +194,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Red":
+                    case { } when value.SequenceEqual("Red".AsSpan()):
                         result = 1;
                         return true;
-                    case "Blue":
+                    case { } when value.SequenceEqual("Blue".AsSpan()):
                         result = 2;
                         return true;
-                    case "Green":
+                    case { } when value.SequenceEqual("Green".AsSpan()):
                         result = 4;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.ErrorCodeJsonConverter.g.cs
@@ -24,6 +24,8 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             return (ErrorCode)0;
         }
 
+    #if NET7_0_OR_GREATER
+
         public override void Write(Utf8JsonWriter writer, ErrorCode value, JsonSerializerOptions options)
         {
             switch ((ushort)value)
@@ -48,7 +50,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         private ushort ReadFromString(ref Utf8JsonReader reader)
         {
-    #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
             if (length > MaxBytesLength)
                 return (ushort)0;
@@ -56,9 +57,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             Span<char> name = stackalloc char[MaxBytesLength];
             int charsWritten = reader.CopyString(name);
             name = name.Slice(0, charsWritten);
-    #else
-            string? name = reader.GetString();
-    #endif
 
             return name switch
             {
@@ -69,5 +67,44 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 _ => Enum.TryParse(name, out ErrorCode result) ? (ushort)result : (ushort)0
             };
         }
+
+    #else
+
+        public override void Write(Utf8JsonWriter writer, ErrorCode value, JsonSerializerOptions options)
+        {
+            switch ((ushort)value)
+            {
+                case 0:
+                    writer.WriteStringValue("NON");
+                    break;
+                case 1:
+                    writer.WriteStringValue("UNK");
+                    break;
+                case 100:
+                    writer.WriteStringValue("CNX");
+                    break;
+                case 200:
+                    writer.WriteStringValue("OUT");
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
+        }
+
+        private ushort ReadFromString(ref Utf8JsonReader reader)
+        {
+            var name = reader.GetString();
+            return name switch
+            {
+                "NON" => (ushort)0,
+                "UNK" => (ushort)1,
+                "CNX" => (ushort)100,
+                "OUT" => (ushort)200,
+                _ => Enum.TryParse(name, out ErrorCode result) ? (ushort)result : (ushort)0
+            };
+        }
+
+    #endif
     }
 }

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.HumanStatesFactory.g.cs
@@ -194,22 +194,22 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Idle":
+                    case { } when value.SequenceEqual("Idle".AsSpan()):
                         result = 1;
                         return true;
-                    case "Working":
+                    case { } when value.SequenceEqual("Working".AsSpan()):
                         result = 2;
                         return true;
-                    case "Sleeping":
+                    case { } when value.SequenceEqual("Sleeping".AsSpan()):
                         result = 3;
                         return true;
-                    case "Eating":
+                    case { } when value.SequenceEqual("Eating".AsSpan()):
                         result = 4;
                         return true;
-                    case "Dead":
+                    case { } when value.SequenceEqual("Dead".AsSpan()):
                         result = 5;
                         return true;
-                    case "Relaxing":
+                    case { } when value.SequenceEqual("Relaxing".AsSpan()):
                         result = 1;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum1Factory.g.cs
@@ -194,13 +194,13 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Zero":
+                    case { } when value.SequenceEqual("Zero".AsSpan()):
                         result = 0;
                         return true;
-                    case "One":
+                    case { } when value.SequenceEqual("One".AsSpan()):
                         result = 1;
                         return true;
-                    case "Two":
+                    case { } when value.SequenceEqual("Two".AsSpan()):
                         result = 2;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum2Factory.g.cs
@@ -194,16 +194,16 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Credit":
+                    case { } when value.SequenceEqual("Credit".AsSpan()):
                         result = 0;
                         return true;
-                    case "Debit":
+                    case { } when value.SequenceEqual("Debit".AsSpan()):
                         result = 1;
                         return true;
-                    case "Cash":
+                    case { } when value.SequenceEqual("Cash".AsSpan()):
                         result = 2;
                         return true;
-                    case "Cheque":
+                    case { } when value.SequenceEqual("Cheque".AsSpan()):
                         result = 3;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.MyEnum3Factory.g.cs
@@ -194,25 +194,25 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Monday":
+                    case { } when value.SequenceEqual("Monday".AsSpan()):
                         result = 0;
                         return true;
-                    case "Tuesday":
+                    case { } when value.SequenceEqual("Tuesday".AsSpan()):
                         result = 1;
                         return true;
-                    case "Wednesday":
+                    case { } when value.SequenceEqual("Wednesday".AsSpan()):
                         result = 2;
                         return true;
-                    case "Thursday":
+                    case { } when value.SequenceEqual("Thursday".AsSpan()):
                         result = 3;
                         return true;
-                    case "Friday":
+                    case { } when value.SequenceEqual("Friday".AsSpan()):
                         result = 4;
                         return true;
-                    case "Saturday":
+                    case { } when value.SequenceEqual("Saturday".AsSpan()):
                         result = 5;
                         return true;
-                    case "Sunday":
+                    case { } when value.SequenceEqual("Sunday".AsSpan()):
                         result = 6;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.PaymentMethodFactory.g.cs
@@ -194,16 +194,16 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Credit":
+                    case { } when value.SequenceEqual("Credit".AsSpan()):
                         result = 0;
                         return true;
-                    case "Debit":
+                    case { } when value.SequenceEqual("Debit".AsSpan()):
                         result = 1;
                         return true;
-                    case "Cash":
+                    case { } when value.SequenceEqual("Cash".AsSpan()):
                         result = 2;
                         return true;
-                    case "Cheque":
+                    case { } when value.SequenceEqual("Cheque".AsSpan()):
                         result = 3;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SeasonJsonConverter.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SeasonJsonConverter.g.cs
@@ -26,6 +26,8 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             throw new JsonException();
         }
 
+    #if NET7_0_OR_GREATER
+
         public override void Write(Utf8JsonWriter writer, Season value, JsonSerializerOptions options)
         {
             switch ((int)value)
@@ -50,7 +52,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
 
         private int ReadFromString(ref Utf8JsonReader reader)
         {
-    #if NET7_0_OR_GREATER
             int length = reader.HasValueSequence ? checked((int)reader.ValueSequence.Length) : reader.ValueSpan.Length;
             if (length > MaxBytesLength)
                 throw new JsonException();
@@ -58,9 +59,6 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             Span<char> name = stackalloc char[MaxBytesLength];
             int charsWritten = reader.CopyString(name);
             name = name.Slice(0, charsWritten);
-    #else
-            string? name = reader.GetString();
-    #endif
 
             return name switch
             {
@@ -71,6 +69,45 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
                 _ => Enum.TryParse(name, out Season result) ? (int)result : throw new JsonException()
             };
         }
+
+    #else
+
+        public override void Write(Utf8JsonWriter writer, Season value, JsonSerializerOptions options)
+        {
+            switch ((int)value)
+            {
+                case 1:
+                    writer.WriteStringValue("🌱");
+                    break;
+                case 2:
+                    writer.WriteStringValue("☀️");
+                    break;
+                case 3:
+                    writer.WriteStringValue("🍂");
+                    break;
+                case 4:
+                    writer.WriteStringValue("⛄");
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
+        }
+
+        private int ReadFromString(ref Utf8JsonReader reader)
+        {
+            var name = reader.GetString();
+            return name switch
+            {
+                "🌱" => 1,
+                "☀️" => 2,
+                "🍂" => 3,
+                "⛄" => 4,
+                _ => Enum.TryParse(name, out Season result) ? (int)result : throw new JsonException()
+            };
+        }
+
+    #endif
 
         private int ReadFromNumber(ref Utf8JsonReader reader)
         {

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.SlimCategoriesFactory.g.cs
@@ -194,22 +194,22 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Electronics":
+                    case { } when value.SequenceEqual("Electronics".AsSpan()):
                         result = 0;
                         return true;
-                    case "Food":
+                    case { } when value.SequenceEqual("Food".AsSpan()):
                         result = 1;
                         return true;
-                    case "Automotive":
+                    case { } when value.SequenceEqual("Automotive".AsSpan()):
                         result = 2;
                         return true;
-                    case "Arts":
+                    case { } when value.SequenceEqual("Arts".AsSpan()):
                         result = 3;
                         return true;
-                    case "BeautyCare":
+                    case { } when value.SequenceEqual("BeautyCare".AsSpan()):
                         result = 4;
                         return true;
-                    case "Fashion":
+                    case { } when value.SequenceEqual("Fashion".AsSpan()):
                         result = 5;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.UserRoleFactory.g.cs
@@ -194,22 +194,22 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "None":
+                    case { } when value.SequenceEqual("None".AsSpan()):
                         result = 0;
                         return true;
-                    case "NormalUser":
+                    case { } when value.SequenceEqual("NormalUser".AsSpan()):
                         result = 1;
                         return true;
-                    case "Custodian":
+                    case { } when value.SequenceEqual("Custodian".AsSpan()):
                         result = 2;
                         return true;
-                    case "Finance":
+                    case { } when value.SequenceEqual("Finance".AsSpan()):
                         result = 4;
                         return true;
-                    case "SuperUser":
+                    case { } when value.SequenceEqual("SuperUser".AsSpan()):
                         result = 6;
                         return true;
-                    case "All":
+                    case { } when value.SequenceEqual("All".AsSpan()):
                         result = 7;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/Raiqub.Generators.EnumUtilities.IntegrationTests.Models.WeekDaysFactory.g.cs
@@ -194,25 +194,25 @@ namespace Raiqub.Generators.EnumUtilities.IntegrationTests.Models
             {
                 switch (value)
                 {
-                    case "Monday":
+                    case { } when value.SequenceEqual("Monday".AsSpan()):
                         result = 0;
                         return true;
-                    case "Tuesday":
+                    case { } when value.SequenceEqual("Tuesday".AsSpan()):
                         result = 1;
                         return true;
-                    case "Wednesday":
+                    case { } when value.SequenceEqual("Wednesday".AsSpan()):
                         result = 2;
                         return true;
-                    case "Thursday":
+                    case { } when value.SequenceEqual("Thursday".AsSpan()):
                         result = 3;
                         return true;
-                    case "Friday":
+                    case { } when value.SequenceEqual("Friday".AsSpan()):
                         result = 4;
                         return true;
-                    case "Saturday":
+                    case { } when value.SequenceEqual("Saturday".AsSpan()):
                         result = 5;
                         return true;
-                    case "Sunday":
+                    case { } when value.SequenceEqual("Sunday".AsSpan()):
                         result = 6;
                         return true;
                     default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Generated/Raiqub.Generators.EnumUtilities/Raiqub.Generators.EnumUtilities.EnumUtilitiesGenerator/_.NoNamespaceFactory.g.cs
@@ -192,13 +192,13 @@ public static partial class NoNamespaceFactory
         {
             switch (value)
             {
-                case "Zero":
+                case { } when value.SequenceEqual("Zero".AsSpan()):
                     result = 0;
                     return true;
-                case "One":
+                case { } when value.SequenceEqual("One".AsSpan()):
                     result = 1;
                     return true;
-                case "Two":
+                case { } when value.SequenceEqual("Two".AsSpan()):
                     result = 2;
                     return true;
                 default:

--- a/tests/EnumUtilities.Generators.IntegrationTests/Models/EmptyEnum.cs
+++ b/tests/EnumUtilities.Generators.IntegrationTests/Models/EmptyEnum.cs
@@ -4,4 +4,6 @@
 
 [EnumGenerator]
 [JsonConverterGenerator]
-public enum EmptyEnum;
+public enum EmptyEnum
+{
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub EnumUtilities!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

- #170

## Details on the issue fix or feature implementation

Refactored the code to address the compatibility issues and ensure smooth functionality across different versions of .NET. The changes include updating string literals to be compatible with .NET 6.0 and modifying pattern matching using Span<char>.

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
