### PR TITLE
ci: Install both .NET 6 and 8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,6 +54,9 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
       with:
+        dotnet-version: |
+          6.x
+          8.x
         global-json-file: global.json
 
     - name: 🗃️ Setup NuGet cache

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,6 +36,9 @@ jobs:
     - name: 🧰 Setup .NET
       uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
       with:
+        dotnet-version: |
+          6.x
+          8.x
         global-json-file: global.json
 
     - name: 🗃️ Setup NuGet cache


### PR DESCRIPTION
<!-- Thank you for contributing to Raiqub EnumUtilities!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
- Build workflow failing because of missing .NET 6

## Details on the issue fix or feature implementation
- Ensure that both .NET 6 and 8 are installed

## Confirm the following

- [x]  I started this PR by branching from the head of the default branch
- [x]  I have targeted the PR to merge into the default branch
- [x]  I have included unit tests for the issue/feature
- [x]  I have successfully run a local build
