### PR TITLE
ci(github-action): add claude.ai to allowed endpoints

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
             api.anthropic.com:443
             api.github.com:443
             bun.sh:443
+            claude.ai:443
             github.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,7 @@ jobs:
             api.anthropic.com:443
             api.github.com:443
             bun.sh:443
+            claude.ai:443
             github.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443


### PR DESCRIPTION
## Summary
- Add `claude.ai:443` to Harden Runner allowed endpoints in both Claude workflows
- Fixes workflow failures caused by blocked access to Claude AI services

## Changes
- Updated `.github/workflows/claude-code-review.yml` to allow `claude.ai:443`
- Updated `.github/workflows/claude.yml` to allow `claude.ai:443`

## Test plan
- [ ] Merge PR to main branch
- [ ] Verify workflows run without being blocked after merge
- [ ] Confirm Harden Runner security configuration remains intact

## Note
The workflow validation error on this PR is expected when modifying workflow files. The updated workflows will take effect after merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)