### PR TITLE
ci(github-action): switch Claude workflows to audit mode with wildcard domains

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,15 +30,17 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
-            api.anthropic.com:443
+            *.anthropic.com:443
+            *.githubapp.com:443
             api.github.com:443
             bun.sh:443
             claude.ai:443
             github.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,15 +29,17 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
-            api.anthropic.com:443
+            *.anthropic.com:443
+            *.githubapp.com:443
             api.github.com:443
             bun.sh:443
             claude.ai:443
             github.com:443
             registry.npmjs.org:443
             release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Switch Harden Runner from `block` to `audit` mode for Claude workflows
- Add wildcard domains: `*.anthropic.com`, `*.githubapp.com`
- Add `storage.googleapis.com` for additional service requirements
- Maintain existing specific endpoints for compatibility

## Changes
- Updated `.github/workflows/claude-code-review.yml`:
  - Changed `egress-policy: block` → `egress-policy: audit`
  - Added wildcard and storage endpoints
- Updated `.github/workflows/claude.yml`:
  - Changed `egress-policy: block` → `egress-policy: audit`
  - Added wildcard and storage endpoints

## Rationale
Audit mode allows workflows to run without being blocked while logging all egress traffic. This helps discover all required endpoints before switching back to block mode with a complete allowed list.

## Added Endpoints
- `*.anthropic.com:443` - All Anthropic API subdomains
- `*.githubapp.com:443` - GitHub App services
- `storage.googleapis.com:443` - Google Cloud Storage

## Test plan
- [ ] Merge PR to main branch
- [ ] Monitor workflow runs in audit mode
- [ ] Review Harden Runner logs to identify all required endpoints
- [ ] Create follow-up PR to switch back to block mode with complete endpoint list

## Note
The workflow validation error on this PR is expected when modifying workflow files. The updated workflows will take effect after merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)