### PR TITLE
ci(github-actions): replace disable-sudo with disable-sudo-and-containers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             *.azureedge.net:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
       with:
-        disable-sudo: true
+        disable-sudo-and-containers: true
         egress-policy: block
         allowed-endpoints: >
           *.azureedge.net:443

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -23,7 +23,7 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
       with:
-        disable-sudo: true
+        disable-sudo-and-containers: true
         egress-policy: block
         allowed-endpoints: >
           *.azureedge.net:443

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,7 +19,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             api.deps.dev:443

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -79,7 +79,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
     - name: 🛡️ Harden Runner
       uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
       with:
-        disable-sudo: true
+        disable-sudo-and-containers: true
         egress-policy: block
         allowed-endpoints: >
           *.azureedge.net:443

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
       - name: 🛡️ Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             *.azureedge.net:443

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
-          disable-sudo: true
+          disable-sudo-and-containers: true
           egress-policy: block
           allowed-endpoints: >
             *.sigstore.dev:443


### PR DESCRIPTION
## Summary
- Replaced `disable-sudo: true` with `disable-sudo-and-containers: true` in all GitHub Actions workflows
- Updated 8 workflow files: codeql.yml, create-tag.yml, docs.yml (2 jobs), dotnet.yml, package.yml, scorecard.yml, dependency-review.yml, and claude-code-review.yml

## Security Improvement
This change prevents container-based privilege escalation via CVE-2025-32955 by:
- Uninstalling Docker packages
- Removing `/var/run/docker.sock` and containerd sockets
- Retaining existing sudo restrictions
- Fully closing the container escape vector

## References
- Closes #340
- See [StepSecurity blog post](https://www.stepsecurity.io/blog/evolving-harden-runners-disable-sudo-policy-for-improved-runner-security) for detailed information about CVE-2025-32955

## Test plan
- [ ] Verify that workflow files have been correctly updated
- [ ] Ensure GitHub Actions runners can execute workflows successfully
- [ ] Confirm that Docker and containerd are disabled on runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)