### PR TITLE
ci(github-actions): re-enable Docker containers for scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:
-          disable-sudo-and-containers: true
+          disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
             *.sigstore.dev:443


### PR DESCRIPTION
## Summary
- Rollback the recent change that disabled containers in the scorecard workflow
- Changes `disable-sudo-and-containers: true` back to `disable-sudo: true`
- The scorecard workflow requires Docker containers to function properly

## Context
This reverts the change from commit fde87d9 for the scorecard.yml workflow, allowing Docker containers to be used again while keeping sudo disabled for security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)