### PR TITLE
fix(ci): correct renovate bot filter and add gh tools for claude workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   claude-review:
     # Skip review for Renovate bot PRs
-    if: github.event.pull_request.user.login != 'app/renovate'
+    if: github.event.pull_request.user.login != 'renovate[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,5 +69,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(dotnet:*)"'
+          claude_args: '--allowed-tools "Bash(dotnet:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Summary

This PR fixes two issues with Claude Code GitHub Actions workflows.

Fixes #458

## Changes

### `.github/workflows/claude-code-review.yml`
- Changed Renovate bot login filter from `'app/renovate'` to `'renovate[bot]'`
- GitHub Actions context uses `'renovate[bot]'` format while the API returns `'app/renovate'`
- This ensures Claude Code reviews are properly skipped for Renovate PRs

### `.github/workflows/claude.yml`
- Added allowed tools: `gh issue view`, `gh search`, `gh issue list`, `gh pr comment`, `gh pr diff`, `gh pr view`, `gh pr list`
- Enables Claude to interact with GitHub issues and pull requests when mentioned

## Test plan

- [x] Verify workflow syntax is valid
- [ ] Test that Claude Code review is skipped on Renovate PRs
- [ ] Test that Claude mention workflow can use gh commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)