### PR TITLE
chore: rollback support to .NET 6 SDK

### DIFF
--- a/EnumUtilities.slnx
+++ b/EnumUtilities.slnx
@@ -7,6 +7,7 @@
         <File Path="version.json" />
     </Folder>
     <Folder Name="/gen/">
+        <Project Path="gen/EnumUtilities.Generators.Roslyn4_3_1/EnumUtilities.Generators.Roslyn4_3_1.csproj" />
         <Project Path="gen/EnumUtilities.Generators.Roslyn4_8_0/EnumUtilities.Generators.Roslyn4_8_0.csproj" />
         <Project Path="gen/EnumUtilities.Generators.Roslyn5_0_0/EnumUtilities.Generators.Roslyn5_0_0.csproj" />
     </Folder>

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ A source generator for C# that uses Roslyn to create extensions and parsers for 
 
 ## Compatibility
 
-Raiqub.Generators.EnumUtilities runs with Roslyn compiler so does not introduce a new dependency to your project besides a library containing the EnumGenerator attribute.
+Raiqub.Generators.EnumUtilities runs with Roslyn compiler so does not introduce a new dependency to your project besides
+a library containing the EnumGenerator attribute.
 
-Version 2.x and later require at least the .NET 8 SDK to build, and at least .NET 6 runtime to run.
-
-**Note:** If you are using .NET SDK 6, please use [version 1.x](https://www.nuget.org/packages/Raiqub.Generators.EnumUtilities/1.12.1) of this package, which supports any .NET Standard 2.0-compatible runtime.
+It requires at least the .NET 6 SDK to run, but you can target earlier frameworks.
 
 ## Documentation
 This README aims to give a quick overview of some Raiqub Enum Utilities features. For deeper detail of available features, be sure also to check out [Documentation Page](https://fgodoy.me/EnumUtilities/).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A source generator for C# that uses Roslyn to create extensions and parsers for 
 Raiqub.Generators.EnumUtilities runs with Roslyn compiler so does not introduce a new dependency to your project besides
 a library containing the EnumGenerator attribute.
 
-It requires at least the .NET 6 SDK to run, but you can target earlier frameworks.
+It requires the .NET 6 SDK or later, and consuming projects must target .NET 6 or later.
 
 ## Documentation
 This README aims to give a quick overview of some Raiqub Enum Utilities features. For deeper detail of available features, be sure also to check out [Documentation Page](https://fgodoy.me/EnumUtilities/).

--- a/gen/EnumUtilities.Generators.Roslyn4_3_1/EnumUtilities.Generators.Roslyn4_3_1.csproj
+++ b/gen/EnumUtilities.Generators.Roslyn4_3_1/EnumUtilities.Generators.Roslyn4_3_1.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <AnalyzerRoslynVersion>4.3.1</AnalyzerRoslynVersion>
+    <DefineConstants>$(DefineConstants);Roslyn_431;AllowUnsafeBlocks;FeatureMemory;NO_RAIQUB_SOURCEGENERATORS_POLYFILL</DefineConstants>
+    <RootNamespace>Raiqub.Generators.EnumUtilities</RootNamespace>
+    <AssemblyName>Raiqub.Generators.EnumUtilities</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Polyfill">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Raiqub.Generators.InterpolationCodeWriter.CSharp.Sources">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\EnumUtilities\*Attribute.cs" LinkBase="Attributes" />
+    <Compile Include="..\..\src\EnumUtilities\Formatters\EnumNumericFormatter.cs" LinkBase="Common" />
+    <Compile Include="..\EnumUtilities.Generators.Roslyn5_0_0\*\*.cs" Exclude="**\obj\**" LinkBase="." />
+    <Compile Include="..\EnumUtilities.Generators.Roslyn5_0_0\CodeWriters\*\*.cs" />
+    <Compile Include="..\EnumUtilities.Generators.Roslyn5_0_0\DiagnosticDescriptors.cs" />
+    <Compile Include="..\EnumUtilities.Generators.Roslyn5_0_0\EnumUtilitiesGenerator.cs" />
+    <Compile Include="..\EnumUtilities.Generators.Roslyn5_0_0\TrackingNames.cs" />
+    <AdditionalFiles Include="..\EnumUtilities.Generators.Roslyn5_0_0\AnalyzerReleases.*.md" />
+  </ItemGroup>
+</Project>

--- a/gen/EnumUtilities.Generators.Roslyn4_3_1/packages.lock.json
+++ b/gen/EnumUtilities.Generators.Roslyn4_3_1/packages.lock.json
@@ -1,0 +1,139 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETStandard,Version=v2.0": {
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[2.0.2, )",
+        "resolved": "2.0.2",
+        "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Direct",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.3.1, )",
+        "resolved": "4.3.1",
+        "contentHash": "5C9VHvahL98tumlyaT/loB5rW+K/6q0UU7uLyT1Dv15YjZraRkqML9u2t2e8GaO7XqEOtBVqK/SlxXOPqwzxog==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.3.1]"
+        }
+      },
+      "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers": {
+        "type": "Direct",
+        "requested": "[3.3.1, )",
+        "resolved": "3.3.1",
+        "contentHash": "eT+kgNCDdTRbQ5WF6BGx1HI3D5jYfHteza/koefhWC2vNZGxObA74XxwWfg40dy3uUv7dn3OGKLK5GUPLroVog=="
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.9.50, )",
+        "resolved": "3.9.50",
+        "contentHash": "HtOgGF6jZ+WYbXnCUCYPT8Y2d6mIJo9ozjK/FINTRsXdm4Zgv9GehUMa7EFoGQkqrMcDJNOIDwCmENnvXg4UbA=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Polyfill": {
+        "type": "Direct",
+        "requested": "[7.33.0, )",
+        "resolved": "7.33.0",
+        "contentHash": "szDcLt4Xu8LLTUXlAq7Q6vq/pAcH0WgU9ldB3GF0XNpI48g9JaZUDNUIJS6h5VQA22cSzVIoc3laHhjOXKorfw=="
+      },
+      "Raiqub.Generators.InterpolationCodeWriter.CSharp.Sources": {
+        "type": "Direct",
+        "requested": "[2.4.2, )",
+        "resolved": "2.4.2",
+        "contentHash": "4eKheKSsK2VdqokfB+ZWRa+buTdyVFVoxHPe+IasLqRhonZNNMKt/zLR9t3ewfej+TPZcvZuMZ88YL/7XQmAsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.3.1",
+        "contentHash": "wexpJffSEEwptwe6UTMxRDZCCtz+XubI4Qewl4JECnNhcQrtb0anhSUEV9Nz7WkoNfWkx1fptR8xh1egoxYrqw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
+          "System.Collections.Immutable": "6.0.0",
+          "System.Memory": "4.5.4",
+          "System.Reflection.Metadata": "5.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.4.0",
+        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "5.0.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encoding.CodePages": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      }
+    }
+  }
+}

--- a/src/EnumUtilities/EnumUtilities.csproj
+++ b/src/EnumUtilities/EnumUtilities.csproj
@@ -12,6 +12,11 @@
 
   <ItemGroup>
     <ProjectReference
+      Include="..\..\gen\EnumUtilities.Generators.Roslyn4_3_1\EnumUtilities.Generators.Roslyn4_3_1.csproj"
+      PackAsAnalyzer="true"
+      ReferenceOutputAssembly="false"
+    />
+    <ProjectReference
       Include="..\..\gen\EnumUtilities.Generators.Roslyn4_8_0\EnumUtilities.Generators.Roslyn4_8_0.csproj"
       PackAsAnalyzer="true"
       ReferenceOutputAssembly="false"


### PR DESCRIPTION
## Summary
- restore compatibility wording to require the .NET 6 SDK instead of .NET 8
- add the Roslyn 4.3.1 analyzer project and lock file to package the rollback path
- include the new generator project in the solution and analyzer package references

## Validation
- branch rebased onto latest origin/main at 402c7c9
- not run: local test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated package guidance to clarify supported compiler and SDK requirements.
  * Added support for an additional compiler version, improving analyzer compatibility.
  * Clarified that the package can target earlier frameworks while requiring at least the .NET 6 SDK to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->